### PR TITLE
Fix expense chart double counting

### DIFF
--- a/expense_labels.py
+++ b/expense_labels.py
@@ -68,3 +68,15 @@ OTHER_OPERATING = [
     "Excise Taxes",
     "Other Operating Expenses",
 ]
+
+# Expense categories that should be ignored entirely. These entries typically
+# represent totals that already include other line items and would otherwise
+# lead to double-counting when stacking expenses.
+IGNORE_CATEGORIES = [
+    "Operating Expense",
+    "Operating Expenses",
+    "Total Operating Expense",
+    "Total Operating Expenses",
+    "Total Expenses",
+    "Operating Income",
+]

--- a/expense_reports.py
+++ b/expense_reports.py
@@ -22,10 +22,18 @@ from matplotlib.ticker import FuncFormatter
 # ──────────────────────────────────────────────────────────────
 # label aliases live in expense_labels.py
 # ──────────────────────────────────────────────────────────────
-from expense_labels import (COST_OF_REVENUE, FACILITIES_DA, GENERAL_AND_ADMIN,
-                            INSURANCE_CLAIMS, OTHER_OPERATING, PERSONNEL_COSTS,
-                            RESEARCH_AND_DEVELOPMENT, SELLING_AND_MARKETING,
-                            SGA_COMBINED)
+from expense_labels import (
+    COST_OF_REVENUE,
+    FACILITIES_DA,
+    GENERAL_AND_ADMIN,
+    INSURANCE_CLAIMS,
+    OTHER_OPERATING,
+    PERSONNEL_COSTS,
+    RESEARCH_AND_DEVELOPMENT,
+    SELLING_AND_MARKETING,
+    SGA_COMBINED,
+    IGNORE_CATEGORIES,
+)
 
 DB_PATH    = "Stock Data.db"
 OUTPUT_DIR = "charts"
@@ -58,9 +66,16 @@ def _clean(v):
 
 
 def _pick_any(row: pd.Series, labels: list[str]):
-    """Return the first non-null column whose name contains ≥1 label substring."""
+    """Return the first non-null column whose name contains ≥1 label substring.
+
+    Columns matching any ignore pattern are skipped to avoid double-counting
+    aggregate totals such as "Operating Expense".
+    """
     for k in row.index:
-        if pd.notna(row[k]) and any(lbl.lower() in k.lower() for lbl in labels):
+        kl = k.lower()
+        if any(ig.lower() in kl for ig in IGNORE_CATEGORIES):
+            continue
+        if pd.notna(row[k]) and any(lbl.lower() in kl for lbl in labels):
             return row[k]
     return None
 


### PR DESCRIPTION
## Summary
- ignore aggregated categories like `Operating Expense` when extracting expense data
- skip ignored categories while mapping raw rows to buckets

## Testing
- `python expense_reports.py`
- `python -m py_compile expense_reports.py`
- `python -m py_compile expense_labels.py`


------
https://chatgpt.com/codex/tasks/task_e_6878c9276468833188338ee0b13f28cc