### PR TITLE
fix: filter bad implied growth rows + robust econ table load

### DIFF
--- a/generate_economic_data.py
+++ b/generate_economic_data.py
@@ -18,8 +18,8 @@ from fredapi import Fred
 
 # ───────────────────── configuration ───────────────────────
 DB_FILE   = Path("Stock Data.db")
-HTML_OUT  = Path("economic_data.html")
 CHART_DIR = Path("charts")
+HTML_OUT  = CHART_DIR / "economic_data.html"
 
 FRED_KEY  = os.getenv("FRED_API_KEY", "").strip()
 fred      = Fred(api_key=FRED_KEY) if FRED_KEY else None
@@ -112,7 +112,7 @@ def generate_economic_data():
     if not fred:
         print("⚠️  FRED_API_KEY missing – skipping economic-data update.")
         HTML_OUT.write_text("Economic data not available", encoding="utf-8")
-        return
+        return HTML_OUT
 
     CHART_DIR.mkdir(exist_ok=True)
     with sqlite3.connect(DB_FILE) as conn:
@@ -158,7 +158,9 @@ def generate_economic_data():
 
         _render_html(pd.DataFrame(summary_rows))
     print("✓ Economic data updated, HTML and charts generated")
+    return HTML_OUT
 
 # -------------------------------------------------------------------
 if __name__ == "__main__":
-    generate_economic_data()
+    html_path = generate_economic_data()
+    print(f"[ECON]  wrote → {html_path}  exists? {html_path.exists()}")

--- a/html_generator2.py
+++ b/html_generator2.py
@@ -3,6 +3,8 @@
 # ----------------------------------------------------------------
 from jinja2 import Environment, FileSystemLoader, Template
 import os, sqlite3, pandas as pd, yfinance as yf
+from pathlib import Path
+from html_generator import get_file_content_or_placeholder
 
 DB_PATH = "Stock Data.db"
 env = Environment(loader=FileSystemLoader("templates"))
@@ -309,7 +311,13 @@ def create_home_page(tickers, dashboard_html, avg_vals, spy_qqq_html,
 def html_generator2(tickers, financial_data, full_dashboard_html,
                     avg_values, spy_qqq_growth_html=""):
     ensure_templates_exist()
-    econ_html = get_file_or_placeholder("economic_data.html", "Economic data not available")
+    charts_path = Path("charts")
+    econ_html = get_file_content_or_placeholder(
+                charts_path / "economic_data.html",
+                placeholder="<!-- Economic data not available -->"
+            )
+    assert "Economic data not available" not in econ_html[:60], \
+       "[ECON]  placeholder detected – file missing"
     create_home_page(
         tickers, full_dashboard_html, avg_values, spy_qqq_growth_html,
         econ_html,

--- a/index_growth_table.py
+++ b/index_growth_table.py
@@ -137,11 +137,21 @@ def _log_today(y):
             ttm_g, fwd_g   = _growth(ttm_pe, y), _growth(fwd_pe, y)
 
             if ttm_g is not None:
-                cur.execute("INSERT OR REPLACE INTO Index_Growth_History VALUES (?,?, 'TTM', ?)",
-                            (today, tk, ttm_g))
+                implied_growth = ttm_g * 100
+                if abs(implied_growth) > 100:          # 100 % hard ceiling
+                    print(f"[INDEX-GROWTH]  Dropping out-of-range value "
+                          f"{implied_growth:.2f}% for {tk} {today}")
+                else:
+                    cur.execute("INSERT OR REPLACE INTO Index_Growth_History VALUES (?,?, 'TTM', ?)",
+                                (today, tk, ttm_g))
             if fwd_g is not None:
-                cur.execute("INSERT OR REPLACE INTO Index_Growth_History VALUES (?,?, 'Forward', ?)",
-                            (today, tk, fwd_g))
+                implied_growth = fwd_g * 100
+                if abs(implied_growth) > 100:          # 100 % hard ceiling
+                    print(f"[INDEX-GROWTH]  Dropping out-of-range value "
+                          f"{implied_growth:.2f}% for {tk} {today}")
+                else:
+                    cur.execute("INSERT OR REPLACE INTO Index_Growth_History VALUES (?,?, 'Forward', ?)",
+                                (today, tk, fwd_g))
 
             if ttm_pe is not None:
                 cur.execute("INSERT OR REPLACE INTO Index_PE_History VALUES (?,?, 'TTM', ?)",


### PR DESCRIPTION
## Summary
- drop impossible implied growth values above 100% before logging to the index growth history
- write economic indicator output to `charts/economic_data.html` and return the path for debugging
- load economic data from the charts folder and assert the file exists to avoid silent failures

## Testing
- `python generate_economic_data.py`
- `python html_generator2.py`
- `python index_growth_table.py` *(fails: curl_cffi.requests.exceptions.ProxyError: Failed to perform, curl: (56) CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68937e5f32508331a199278e4aa5e5a5