### PR TITLE
fix: call econ generator first + remove duplicate heading

### DIFF
--- a/generate_economic_data.py
+++ b/generate_economic_data.py
@@ -114,13 +114,10 @@ def _render_html(rows: list[dict]):
         return hdr + "".join(body) + "</tbody></table>"
 
     html = [
-        '<div class="econ-wrap">',
-        f'<h2>Key U.S. Economic Indicators</h2>',
         f'<p class="stamp">Updated: {TODAY_ISO} &nbsp;|&nbsp; Sources: '
         'BLS · FRED · BEA · U.S. Treasury</p>',
         _block("Labor & Prices", labor, "1-mo Δ", "YoY Δ"),
-        _block("Rates & Growth", rates, "1-wk Δ", "3-mo / QoQ Δ"),
-        '</div>'
+        _block("Rates & Growth", rates, "1-wk Δ", "3-mo / QoQ Δ")
     ]
     HTML_OUT.write_text("\n".join(html), encoding="utf-8")
 

--- a/main_remote.py
+++ b/main_remote.py
@@ -130,6 +130,7 @@ def fetch_10_year_treasury_yield():
 # Main
 # ────────────────────────────────────────────────────────────────────
 def mini_main():
+    generate_economic_data()
     financial_data, dashboard_data = {}, []
     treasury = fetch_10_year_treasury_yield()
 
@@ -141,7 +142,6 @@ def mini_main():
     try:
         cursor = conn.cursor()
         process_update_growth_csv(UPDATE_GROWTH_CSV, DB_PATH)
-        generate_economic_data()
 
         for ticker in tickers:
             print(f"[main] Processing {ticker}")


### PR DESCRIPTION
## Summary
- invoke economic data generation before building dashboard
- drop redundant heading in economic data HTML

## Testing
- `pytest Test -q` *(fails: ImportError: cannot import name '_pick' from 'generate_earnings_tables')*

------
https://chatgpt.com/codex/tasks/task_e_689491e1ce9c83319f56755cb4c328e7