### PR TITLE
Ensure segment tables generated and rendered correctly

### DIFF
--- a/html_generator2.py
+++ b/html_generator2.py
@@ -251,7 +251,7 @@ td{padding:4px;border:1px solid #8080FF}
         const allKids = Array.from(host.childNodes);
         const h3s = allKids.filter(n => n.nodeType === 1 && n.tagName === 'H3');
 
-        if(h3s.length === 0) return; // no <h3> → leave combined content as-is
+        if(h3s.length <= 1) return; // 0 or 1 <h3> → leave combined content as-is
 
         // Preserve any preface nodes BEFORE the first <h3> (e.g., caption/unit note)
         const firstH3Index = allKids.indexOf(h3s[0]);

--- a/main_remote.py
+++ b/main_remote.py
@@ -214,6 +214,12 @@ def mini_main():
                 print(f"[WARN] Skipping remaining steps for {ticker} due to error: {e}")
                 continue
 
+        # Fail fast if any ticker lacked a segment table
+        if missing_segments:
+            raise RuntimeError(
+                "Missing segment tables for: " + ", ".join(missing_segments)
+            )
+
         # 3) Post-run generators
         eps_dividend_generator()
         generate_all_summaries()
@@ -236,12 +242,6 @@ def mini_main():
             avg_vals,
             spy_qqq_html
         )
-
-        # Quick visibility: which tickers are missing segment tables?
-        if missing_segments:
-            head = ", ".join(missing_segments[:30])
-            tail = " …" if len(missing_segments) > 30 else ""
-            print(f"[segments] Missing tables for {len(missing_segments)} tickers: {head}{tail}")
 
         # 5) Optional: Generate a one-page freshness report under charts/
         try:


### PR DESCRIPTION
## Summary
- Fail the build if any ticker is missing its segment table so pages always receive valid data.
- Only build segment tabs when more than one `<h3>` section exists to avoid unnecessary tab UI.

## Testing
- `python -m py_compile main_remote.py html_generator2.py generate_segment_charts.py`
- `python generate_segment_charts.py --tickers_csv tickers_sample.csv --output_dir charts` (failed: HTTPSConnectionPool(host='data.sec.gov', port=443): Max retries exceeded)
- `python main_remote.py` (failed: curl_cffi.requests.exceptions.ProxyError: Failed to perform, curl: (56) CONNECT tunnel failed, response 403)


------
https://chatgpt.com/codex/tasks/task_e_68a7826f10348331a4305cdaef8a8ef0