### PR TITLE
Generate segment tables before rendering and improve lookup

### DIFF
--- a/main_remote.py
+++ b/main_remote.py
@@ -190,8 +190,10 @@ def mini_main():
             print(f"[main] Processing {ticker}")
             try:
                 # Ensure segments exist up front so pages can include them later
+                expected = Path(CHARTS_DIR) / ticker / f"{ticker}_segments_table.html"
                 ok = build_segments_for_ticker(ticker)
                 if not ok:
+                    print(f"[segments:WARN] Expected not found: {expected}")
                     missing_segments.append(ticker)
 
                 # Financial pipelines


### PR DESCRIPTION
## Summary
- Add robust helper to read first matching segment table file and tag source path.
- Explicitly pass charts directory when generating pages.
- Generate segment charts/tables for each ticker before other processing in main.
- Move segment generation/warning logic to the main remote runner and drop the redundant code in main.py.

## Testing
- `python -m py_compile html_generator2.py main_remote.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a78b1aeab8833185467e4191737955