### PR TITLE
Generate segment tables before page build and improve lookup

### DIFF
--- a/generate_segment_charts.py
+++ b/generate_segment_charts.py
@@ -140,6 +140,7 @@ def generate_segment_charts_for_ticker(ticker: str, out_dir: Path) -> None:
         out_dir = Path(out_dir)
     except Exception:
         out_dir = canonical_dir
+    # Guard against callers passing a non canonical directory (e.g., charts/TEST)
     if out_dir.resolve().name.upper() != ticker.upper():
         out_dir = canonical_dir
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/html_generator2.py
+++ b/html_generator2.py
@@ -491,10 +491,10 @@ def generate_dashboard_table(raw_rows):
         "Nicks_TTM_Value_Median":        ttm.median(),
         "Nicks_Forward_Value_Average":   fwd.mean(),
         "Nicks_Forward_Value_Median":    fwd.median(),
-        "Finviz_TTM Value_Average":      fttm.mean() if not fttm.empty else None,
-        "Finviz_TTM Value_Median":       fttm.median() if not fttm.empty else None,
-        "Finviz_Forward Value_Average":  ffwd.mean() if not fttm.empty else None,
-        "Finviz_Forward Value_Median":   ffwd.median() if not fttm.empty else None
+        "Finviz_TTM_Value_Average":      fttm.mean() if not fttm.empty else None,
+        "Finviz_TTM_Value_Median":       fttm.median() if not fttm.empty else None,
+        "Finviz_Forward_Value_Average":  ffwd.mean() if not fttm.empty else None,
+        "Finviz_Forward_Value_Median":   ffwd.median() if not fttm.empty else None
     }
 
 # ───────── ancillary page builders (retro-injected) ───────
@@ -538,17 +538,13 @@ def prepare_and_generate_ticker_pages(tickers, charts_dir_fs="charts"):
                 "implied_growth_table_html":     get_file_or_placeholder(f"{charts_dir_fs}/{t}_implied_growth_summary.html", "No implied growth data available."),
                 "segment_table_html":            get_first_file(
                                                     [
-                                                        # canonical (subfolder)
-                                                        f"{charts_dir_fs}/{t}/{t}_segments_table.html",
-                                                        f"{charts_dir_fs}/{t}/segments_table.html",
-                                                        f"{charts_dir_fs}/{t}/segment_performance.html",
-                                                        f"{charts_dir_fs}/{t}/*segments_table.html",
-                                                        # root compatibility copies
-                                                        f"{charts_dir_fs}/{t}_segments_table.html",
-                                                        f"{charts_dir_fs}/{t}_segment_performance.html",
-                                                        f"{charts_dir_fs}/*{t}*_segments_table.html",
+                                                        f"{charts_dir_fs}/{t}/{t}_segments_table.html",   # canonical
+                                                        f"{charts_dir_fs}/{t}/segments_table.html",       # alias
+                                                        f"{charts_dir_fs}/{t}/segment_performance.html",  # alias
+                                                        f"{charts_dir_fs}/{t}/*segments_table.html",      # future variants
+                                                        f"{charts_dir_fs}/*{t}*_segments_table.html",     # root stray fallback
                                                     ],
-                                                    f"No segment data available for {t}."
+                                                    f"No segment data available for {t}.",
                                                 ),
 
                 # Images (web paths)


### PR DESCRIPTION
## Summary
- Build segment tables for all tickers before running the main pipeline and hard-fail if any are missing
- Use glob-aware search to locate segment table HTML files and fix dashboard summary key names
- Clarify canonical output directory guard in segment chart generator

## Testing
- `python -m py_compile main_remote.py html_generator2.py generate_segment_charts.py`
- `python generate_segment_charts.py --tickers_csv tickers.csv --output_dir charts` *(fails: HTTPSConnectionPool(host='data.sec.gov', port=443): Max retries exceeded with url: /api/xbrl/companyfacts/CIK0000100517.json (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))*
- `python main_remote.py` *(fails: curl_cffi.requests.exceptions.ProxyError: Failed to perform, curl: (56) CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ac369677948331abc4bd99b7d181b7