### PR TITLE
Broaden axis recognition for segment data

### DIFF
--- a/sec_segment_data_arelle.py
+++ b/sec_segment_data_arelle.py
@@ -43,25 +43,28 @@ OPINC_BASE_TAGS = {"OperatingIncomeLoss"}
 
 # Canonical axis names we keep
 AXIS_NORMALIZER = {
-    # Geography
+    # Geography → canonical "GeographicalAreasAxis"
     "StatementGeographicalAxis": "GeographicalAreasAxis",
     "GeographicalAreasAxis": "GeographicalAreasAxis",
-    "GeographicalRegionsAxis": "GeographicalRegionsAxis",
-    "GeographicalRegionAxis": "GeographicalRegionsAxis",
+    "GeographicalRegionsAxis": "GeographicalAreasAxis",
+    "GeographicalRegionAxis": "GeographicalAreasAxis",
     "DomesticAndForeignAxis": "DomesticAndForeignAxis",
     "CountryAxis": "CountryAxis",
-    # Product/Service
+
+    # Product / Service → canonical "ProductsAndServicesAxis"
     "ProductOrServiceAxis": "ProductsAndServicesAxis",
     "ProductsAndServicesAxis": "ProductsAndServicesAxis",
-    "ProductLineAxis": "ProductLineAxis",
-    "ProductAxis": "ProductAxis",
-    "ProductCategoryAxis": "ProductCategoryAxis",
-    "ProductCategoriesAxis": "ProductCategoryAxis",
+    "ProductLineAxis": "ProductsAndServicesAxis",
+    "ProductAxis": "ProductsAndServicesAxis",
+    "ProductCategoryAxis": "ProductsAndServicesAxis",
+    "ProductCategoriesAxis": "ProductsAndServicesAxis",
+
     # Operating segments
     "OperatingSegmentsAxis": "OperatingSegmentsAxis",
     "BusinessSegmentsAxis": "OperatingSegmentsAxis",
     "ReportableSegmentsAxis": "OperatingSegmentsAxis",
     "SegmentsAxis": "OperatingSegmentsAxis",
+
     # Customers / Channels
     "MajorCustomersAxis": "MajorCustomersAxis",
     "SignificantCustomersAxis": "MajorCustomersAxis",


### PR DESCRIPTION
## Summary
- normalize additional axis names, mapping geographic, product/service, segment, and channel axes to their canonical forms
- derive whitelist from canonical axis set

## Testing
- `python - <<'PY'
import sec_segment_data_arelle as s
for ticker in ('AAPL','MSFT'):
    df = s.get_segment_data(ticker)
    print(ticker, 'rows', len(df))
PY` *(fails: HTTPSConnectionPool(host='data.sec.gov', port=443): Max retries exceeded due to ProxyError/ConnectionError)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d851dacc833186dc631f729bc213