### PR TITLE
feat: robust chart-table pairing

### DIFF
--- a/generate_segment_charts.py
+++ b/generate_segment_charts.py
@@ -224,8 +224,12 @@ def generate_segment_charts_for_ticker(ticker: str, out_dir: Path, force: bool =
     df = get_segment_data(ticker)
 
     # NEW: if SEC data is empty, **do not overwrite** any existing table
-    if df is None or df.empty:
-        print(f"[segments] {ticker}: SEC returned no segment data; leaving existing artifacts untouched.")
+    if df is None or (hasattr(df, "empty") and df.empty):
+        if not table_path.exists():
+            table_path.write_text(f"<p>No segment data available for {ticker}.</p>", encoding="utf-8")
+        print(
+            f"[segments] {ticker}: SEC returned no segment data; leaving existing table untouched at {table_path}"
+        )
         return
 
     df = df.copy()

--- a/html_generator2.py
+++ b/html_generator2.py
@@ -140,7 +140,7 @@ def build_segment_carousel_html(ticker: str, charts_dir_fs: str, charts_dir_web:
         parts.append(f'<h3>{title}</h3>\n'
                      f'<div class="carousel-container chart-block">\n' + "\n".join(items) + "\n</div>")
 
-    if legacy_srcs:
+    if not parts and legacy_srcs:
         # Use a title that can match a table section
         items = [f'<div class="carousel-item"><img class="chart-img" src="{src}" alt="{ticker} Unlabeled Axis"></div>'
                  for src in legacy_srcs]
@@ -148,6 +148,12 @@ def build_segment_carousel_html(ticker: str, charts_dir_fs: str, charts_dir_web:
                      '<div class="carousel-container chart-block">\n' + "\n".join(items) + "\n</div>")
 
     return "\n".join(parts)
+
+def _canon(title: str) -> str:
+    """
+    Canonicalize a section title so minor diffs (case/spacing/punct) still match.
+    """
+    return re.sub(r"[^a-z0-9]", "", (title or "").lower())
 
 def _split_h3_sections(html: str, wanted_class: str = None):
     """
@@ -175,35 +181,52 @@ def _split_h3_sections(html: str, wanted_class: str = None):
 
 def interleave_segment_blocks(carousel_html: str, table_html: str) -> str:
     """
-    For each axis title: render [charts row] then [matching table].
-    Falls back to an inline notice if a table section is missing.
+    For each axis: render [charts row] then [matching table].
+    - Canonicalizes titles to tolerate small diffs.
+    - If there's only one table section, use it as fallback for any chart group.
     """
     car = _split_h3_sections(carousel_html, wanted_class="carousel-container")
     tab = _split_h3_sections(table_html,   wanted_class="table-wrap")
 
+    # Build maps keyed by canonical titles
     car_map = {}
     order = []
     for title, body in car:
-        if title not in car_map:
-            order.append(title)
-            car_map[title] = []
-        car_map[title].append(body)
+        k = _canon(title)
+        if k not in car_map:
+            order.append(k)
+            car_map[k] = []
+        car_map[k].append((title, body))
 
-    tab_map = {title: body for title, body in tab}
+    tab_map = { _canon(title): (title, body) for title, body in tab }
+
+    # Single-table fallback (common when only one section is generated)
+    fallback = next(iter(tab_map.values())) if len(tab_map) == 1 else None
 
     blocks = []
-    for title in order:
-        table_part = tab_map.get(title, '<div class="table-wrap"><p>No table for this axis.</p></div>')
-        for body in car_map[title]:
-            blocks.append(f'<div class="seg-axis-block">\n<h3>{title}</h3>\n{body}\n{table_part}\n</div>')
+    for k in order:
+        _table_title, table_body = tab_map.get(
+            k, fallback or ("", '<div class="table-wrap"><p>No table for this axis.</p></div>')
+        )
+        for orig_title, body in car_map[k]:
+            blocks.append(
+                f'<div class="seg-axis-block">\n'
+                f'  <h3>{orig_title}</h3>\n'
+                f'  {body}\n'
+                f'  {table_body}\n'
+                f'</div>'
+            )
 
-    # tables that have no charts
-    for title, body in tab_map.items():
-        if title not in car_map:
-            blocks.append(f'<div class="seg-axis-block">\n<h3>{title}</h3>\n{body}\n</div>')
-
-    html = "\n".join(blocks).strip()
-    return html or (table_html or "")
+    # Tables that have no charts
+    for k2, (t_title, t_body) in tab_map.items():
+        if k2 not in car_map:
+            blocks.append(
+                f'<div class="seg-axis-block">\n'
+                f'  <h3>{t_title}</h3>\n'
+                f'  {t_body}\n'
+                f'</div>'
+            )
+    return "\n".join(blocks).strip() or (table_html or "")
 
 # ───────── template creation ────────────────────────────────────
 def ensure_templates_exist():


### PR DESCRIPTION
## Summary
- avoid duplicate legacy 'Unlabeled Axis' blocks and clarify missing table notice
- guard segment chart generation from overwriting existing tables when SEC data is empty
- remove unused variable from interleaver to satisfy linters

## Testing
- `python -m py_compile generate_segment_charts.py html_generator2.py`
- `python - <<'PY'
from pathlib import Path
from generate_segment_charts import generate_segment_charts_for_ticker
generate_segment_charts_for_ticker('AAPL', Path('charts')/'AAPL')
PY` *(fails: ProxyError 403)*
- `python - <<'PY'
from html_generator2 import prepare_and_generate_ticker_pages
prepare_and_generate_ticker_pages(['AAPL'])
print('done')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b0e4a93b888331a015126f904f8ead