### PR TITLE
Ensure headless segment chart generation and log PNG output

### DIFF
--- a/.github/workflows/pre_segment_charts.yml
+++ b/.github/workflows/pre_segment_charts.yml
@@ -12,7 +12,9 @@ jobs:
   pre-segment-charts:
     runs-on: ubuntu-latest
     env:
-      SEC_USER_AGENT: "StockFinances/1.0 (Contact: ${{ secrets.Email }})"
+      SEC_EMAIL: ${{ secrets.EMAIL }}
+      SEC_USER_AGENT: "StockFinances/1.0 (Contact: ${{ secrets.EMAIL }})"
+      MPLBACKEND: Agg
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -26,7 +28,7 @@ jobs:
           if [ -f requirements.txt ]; then
             pip install -r requirements.txt
           fi
-          pip install pandas matplotlib requests beautifulsoup4 lxml
+          pip install pandas matplotlib requests beautifulsoup4 lxml yfinance
       - name: Pre-run segment charts
         run: python generate_segment_charts.py --tickers_csv tickers.csv --output_dir charts
       - name: Upload charts artifact
@@ -35,12 +37,10 @@ jobs:
           name: pre-segment-charts
           path: charts/
           if-no-files-found: warn
-      - name: Set up git identity
+      - name: Commit charts & tables
         run: |
-          git config --global user.name 'ndaly111'
-          git config --global user.email 'ndaly111@gmail.com'
-      - name: Commit results
-        run: |
-          git add charts || true
-          git commit -m "Automated pre segment charts" || echo "No changes to commit"
-          git push || true
+          git config user.name "github-actions"
+          git config user.email "actions@github.com"
+          git add charts/**/*.png charts/**/*.html || true
+          git diff --cached --quiet || git commit -m "Update segment charts/tables"
+          git push

--- a/.github/workflows/segment_charts.yml
+++ b/.github/workflows/segment_charts.yml
@@ -12,8 +12,9 @@ jobs:
   run-segment-charts:
     runs-on: ubuntu-latest
     env:
-      SEC_USER_AGENT: "StockFinances/1.0 (Contact: ${{ secrets.Email }})"
+      SEC_USER_AGENT: "StockFinances/1.0 (Contact: ${{ secrets.EMAIL }})"
       SEC_EMAIL: ${{ secrets.EMAIL }}
+      MPLBACKEND: Agg
     steps:
     - name: Check out repository
       uses: actions/checkout@v4
@@ -29,7 +30,7 @@ jobs:
         if [ -f requirements.txt ]; then
           pip install -r requirements.txt
         fi
-        pip install pandas matplotlib requests beautifulsoup4 lxml
+        pip install pandas matplotlib requests beautifulsoup4 lxml yfinance
 
     - name: Generate segment charts
       run: |
@@ -42,15 +43,10 @@ jobs:
         path: charts/
         if-no-files-found: warn
 
-    - name: Set up Git identity
-      run: |
-        git config --global user.name 'ndaly111'
-        git config --global user.email 'ndaly111@gmail.com'
-
-    - name: Commit charts and pages
+    - name: Commit charts & tables
       run: |
         git config user.name "github-actions"
         git config user.email "actions@github.com"
-        git add charts/**/*.png charts/**/*.html pages/*.html index.html
-        git commit -m "Update charts & segment tables [skip ci]" || echo "No changes"
+        git add charts/**/*.png charts/**/*.html pages/*.html index.html || true
+        git diff --cached --quiet || git commit -m "Update segment charts/tables"
         git push

--- a/generate_segment_charts.py
+++ b/generate_segment_charts.py
@@ -253,7 +253,7 @@ def generate_segment_charts_for_ticker(ticker: str, out_dir: Path, force: bool =
     years_all = sorted(set(df["Year"].tolist()), key=lambda s: (not s.isdigit(), s))
     years_tbl = _last3_plus_ttm(list(df["Year"].unique()))
 
-    written_pngs: List[str] = []
+    written_pngs: List[Path] = []
     for (axis, seg), seg_df in df.groupby(["AxisType", "Segment"], dropna=False):
         revenues   = [seg_df.loc[seg_df["Year"] == y, "Revenue"].sum() for y in years_all]
         op_incomes = [seg_df.loc[seg_df["Year"] == y, "OpIncome"].sum() for y in years_all]
@@ -280,9 +280,10 @@ def generate_segment_charts_for_ticker(ticker: str, out_dir: Path, force: bool =
         safe_seg = _safe_seg_filename(seg)
         axis_slug = _slug(axis_label)
         out_name = f"{ticker}_{axis_slug}_{safe_seg}.png"
-        plt.savefig(out_dir / out_name)
+        out_path = out_dir / out_name
+        plt.savefig(out_path)
         plt.close(fig)
-        written_pngs.append(out_name)
+        written_pngs.append(out_path)
 
     # Build the combined table (unchanged logic)
     def pv(col: str, sub_df: pd.DataFrame) -> pd.DataFrame:
@@ -357,6 +358,8 @@ def generate_segment_charts_for_ticker(ticker: str, out_dir: Path, force: bool =
     content = css + "\n" + caption + "\n" + "\n<hr/>\n".join(sections_html)
     table_path.write_text(content, encoding="utf-8")
     print(f"[{VERSION}] wrote {table_path} ({table_path.stat().st_size} bytes)")
+    for p in written_pngs:
+        print(f"[{VERSION}] emitted {p}")
 
     # NEW: mark success
     _write_seg_stamp(ticker, earnings_dt)


### PR DESCRIPTION
## Summary
- log each emitted segment chart PNG for easier CI debugging
- set `MPLBACKEND=Agg` in segment chart workflows to avoid display server dependency
- commit generated segment charts and tables in CI and ensure required `SEC_EMAIL` secret and `yfinance` dependency

## Testing
- `SEC_EMAIL=test@example.com python generate_segment_charts.py --tickers_csv /tmp/tickers_aapl.csv --output_dir /tmp/charts_aapl` *(fails: ProxyError: Tunnel connection failed: 403 Forbidden)*
- `MPLBACKEND=Agg pytest Test` *(fails: cannot import name '_pick' from 'generate_earnings_tables')*

------
https://chatgpt.com/codex/tasks/task_e_68b10c7f4dbc8331997b1c873d159e66