### PR TITLE
Fix multi-axis segment aggregation

### DIFF
--- a/generate_segment_charts.py
+++ b/generate_segment_charts.py
@@ -138,18 +138,22 @@ def _humanize_segment_name(raw: str) -> str:
 
 def _norm_axis_label(axis: Optional[str]) -> str:
     s = (axis or "").strip()
-    s = re.sub(r".*:", "", s)
-    s = s.replace("Axis", "")
-    s = re.sub(r"([a-z])([A-Z])", r"\1 \2", s)
-    s = s.replace("_", " ").strip()
-    if not s:
-        return "Unlabeled Axis"
-    s = s.replace("Geographical Areas", "Regions")
-    s = s.replace("Geographical Region", "Regions")
-    s = s.replace("Domestic And Foreign", "Domestic vs Foreign")
-    s = s.replace("Products And Services", "Products / Services")
-    s = re.sub(r"\s+", " ", s)
-    return s.title()
+    parts = [p for p in s.split("+") if p]
+    labels: List[str] = []
+    for part in parts:
+        p = re.sub(r".*:", "", part)
+        p = p.replace("Axis", "")
+        p = re.sub(r"([a-z])([A-Z])", r"\1 \2", p)
+        p = p.replace("_", " ").strip()
+        if not p:
+            p = "Unlabeled Axis"
+        p = p.replace("Geographical Areas", "Regions")
+        p = p.replace("Geographical Region", "Regions")
+        p = p.replace("Domestic And Foreign", "Domestic vs Foreign")
+        p = p.replace("Products And Services", "Products / Services")
+        p = re.sub(r"\s+", " ", p)
+        labels.append(p.title())
+    return " & ".join(labels) if labels else "Unlabeled Axis"
 
 def _to_float(x):
     if pd.isna(x): return pd.NA

--- a/generate_segment_tables.py
+++ b/generate_segment_tables.py
@@ -45,18 +45,22 @@ def _humanize_segment_name(raw: str) -> str:
 
 def _norm_axis_label(axis: Optional[str]) -> str:
     s = (axis or "").strip()
-    s = re.sub(r".*:", "", s)
-    s = s.replace("Axis", "")
-    s = re.sub(r"([a-z])([A-Z])", r"\1 \2", s)
-    s = s.replace("_", " ").strip()
-    if not s:
-        return "Unlabeled Axis"
-    s = s.replace("Geographical Areas", "Regions")
-    s = s.replace("Geographical Region", "Regions")
-    s = s.replace("Domestic And Foreign", "Domestic vs Foreign")
-    s = s.replace("Products And Services", "Products / Services")
-    s = re.sub(r"\s+", " ", s)
-    return s.title()
+    parts = [p for p in s.split("+") if p]
+    labels: List[str] = []
+    for part in parts:
+        p = re.sub(r".*:", "", part)
+        p = p.replace("Axis", "")
+        p = re.sub(r"([a-z])([A-Z])", r"\1 \2", p)
+        p = p.replace("_", " ").strip()
+        if not p:
+            p = "Unlabeled Axis"
+        p = p.replace("Geographical Areas", "Regions")
+        p = p.replace("Geographical Region", "Regions")
+        p = p.replace("Domestic And Foreign", "Domestic vs Foreign")
+        p = p.replace("Products And Services", "Products / Services")
+        p = re.sub(r"\s+", " ", p)
+        labels.append(p.title())
+    return " & ".join(labels) if labels else "Unlabeled Axis"
 
 def _choose_scale(max_abs_value: float):
     if not isinstance(max_abs_value, (int, float)) or pd.isna(max_abs_value) or max_abs_value == 0:

--- a/sec_segment_data_arelle.py
+++ b/sec_segment_data_arelle.py
@@ -9,8 +9,7 @@ Outputs a DataFrame with columns:
   OpIncome (float, USD; NaN if unavailable)
   AxisType (canonical axis name: ProductsAndServicesAxis, GeographicalAreasAxis, etc.)
 
-Notes
-- Aggregates across *all* axes present; if a fact has multiple dimensions, it contributes to each axis section.
+- Combines multiple axes into a single composite axis so each fact contributes once.
 - Filters to USD-like units.
 - Polite SEC headers and small delay (PAUSE_SEC).
 """
@@ -207,6 +206,13 @@ def _collect_items(kind: str, all_facts: dict) -> List[dict]:
     return items
 
 def _harvest_tag_multi(all_items: List[dict]) -> Dict[Tuple[str, str, str], float]:
+    """Aggregate items by axis combination, avoiding double counting.
+
+    If a fact has multiple axes, those axes are joined into a single
+    composite key (e.g. "ProductsAndServicesAxis+GeographicalAreasAxis") and
+    the member labels are joined with " | " so the fact contributes only once
+    to the totals.
+    """
     agg: Dict[Tuple[str, str, str], float] = {}
     for it in all_items:
         segs = it.get("segments") or it.get("segment")
@@ -220,10 +226,29 @@ def _harvest_tag_multi(all_items: List[dict]) -> Dict[Tuple[str, str, str], floa
             val = float(it.get("val"))
         except Exception:
             continue
-        for axis, label in axes:
-            key = (axis, label, str(year))
-            agg[key] = agg.get(key, 0.0) + val
+        axes_sorted = sorted(axes, key=lambda x: x[0])
+        axis_key = "+".join(a for a, _ in axes_sorted)
+        label_key = " | ".join(lbl for _, lbl in axes_sorted)
+        key = (axis_key, label_key, str(year))
+        agg[key] = agg.get(key, 0.0) + val
     return agg
+
+def _total_company_revenue(all_items: List[dict]) -> Dict[str, float]:
+    """Aggregate unsegmented revenue items by year."""
+    totals: Dict[str, float] = {}
+    for it in all_items:
+        segs = it.get("segments") or it.get("segment")
+        if _coerce_segments_list(segs):
+            continue  # skip segmented facts
+        year = _year_from_item(it)
+        if not year:
+            continue
+        try:
+            val = float(it.get("val"))
+        except Exception:
+            continue
+        totals[str(year)] = totals.get(str(year), 0.0) + val
+    return totals
 
 def get_segment_data(ticker: str) -> pd.DataFrame:
     cik = _cik_from_ticker(ticker)
@@ -235,6 +260,7 @@ def get_segment_data(ticker: str) -> pd.DataFrame:
 
     rev_agg = _harvest_tag_multi(rev_items)
     op_agg  = _harvest_tag_multi(op_items)
+    totals_company = _total_company_revenue(rev_items)
 
     keys = set(rev_agg.keys()) | set(op_agg.keys())
     if not keys:
@@ -254,4 +280,15 @@ def get_segment_data(ticker: str) -> pd.DataFrame:
     df["Revenue"] = pd.to_numeric(df["Revenue"], errors="coerce")
     df["OpIncome"] = pd.to_numeric(df["OpIncome"], errors="coerce")
     df = df[df["Segment"].astype(str).str.strip() != ""].copy()
+
+    # Validate that segment totals roughly match reported company revenue
+    try:
+        seg_totals = df.groupby("Year")["Revenue"].sum(min_count=1).to_dict()
+        for yr, tot in totals_company.items():
+            seg = seg_totals.get(yr)
+            if seg is not None and abs(seg - tot) > 1.0:  # tolerance for rounding
+                print(f"[segments] WARNING {ticker} {yr}: segments {seg} != reported {tot}")
+    except Exception:
+        pass
+
     return df


### PR DESCRIPTION
## Summary
- prevent multi-axis facts from being counted multiple times by combining dimensions into a single composite axis
- normalize axis labels in charts and tables to support combined axis names
- warn when segment totals don't match unsegmented company revenue

## Testing
- `python -m py_compile sec_segment_data_arelle.py generate_segment_charts.py generate_segment_tables.py`
- `python - <<'PY'
from sec_segment_data_arelle import get_segment_data
get_segment_data('AAPL')
PY` *(fails: ProxyError 403 to data.sec.gov)*

------
https://chatgpt.com/codex/tasks/task_e_68b24d094fac8331a1d635aca7216ef4