### PR TITLE
Refactor segment chart utilities

### DIFF
--- a/segment_formatting_helpers.py
+++ b/segment_formatting_helpers.py
@@ -10,25 +10,28 @@ import pandas as pd
 def _humanize_segment_name(raw: str) -> str:
     """Convert XBRL segment member names to readable labels."""
     if not isinstance(raw, str) or not raw:
-        return raw
-    name = raw.replace("SegmentMember", "")
+        return str(raw)
+    name = str(raw)
+    # strip common XBRL suffixes and tidy spaced capitals
+    name = name.replace('SegmentMember', '')
+    name = re.sub(r'\s*(Member|Segment)\s*$', '', name, flags=re.IGNORECASE)
+    name = re.sub(r'\b([A-Z])\s+([A-Z])\b', r'\1\2', name)
     name = re.sub(r'(?<!^)(?=[A-Z])', ' ', name).strip()
     fixes = {
-        "Greater China": "Greater China",
-        "Rest Of Asia Pacific": "Rest of Asia Pacific",
-        "North America": "North America",
-        "Latin America": "Latin America",
-        "United States": "United States",
-        "Middle East": "Middle East",
-        "Asia Pacific": "Asia Pacific",
-        "Americas": "Americas",
-        "Europe": "Europe",
-        "Japan": "Japan",
-        "China": "China",
+        'Greater China': 'Greater China',
+        'Rest Of Asia Pacific': 'Rest of Asia Pacific',
+        'North America': 'North America',
+        'Latin America': 'Latin America',
+        'United States': 'United States',
+        'Middle East': 'Middle East',
+        'Asia Pacific': 'Asia Pacific',
+        'Americas': 'Americas',
+        'Europe': 'Europe',
+        'Japan': 'Japan',
+        'China': 'China',
     }
-    title = " ".join(w if w.isupper() else w.capitalize() for w in name.split())
+    title = ' '.join(w if w.isupper() else w.capitalize() for w in name.split())
     return fixes.get(title, title)
-
 
 def _to_float(x):
     if pd.isna(x):


### PR DESCRIPTION
## Summary
- require SEC email and share formatting helpers across segment scripts
- store generated segment PNG metadata for bisseg naming and re-run checks
- streamline table building with normalized numeric parsing

## Testing
- `python -m py_compile generate_segment_charts.py generate_segment_tables.py segment_formatting_helpers.py`


------
https://chatgpt.com/codex/tasks/task_e_68b614d4dec08331b23681f52e4af469