### PR TITLE
Fix indentation error in html_generator

### DIFF
--- a/html_generator.py
+++ b/html_generator.py
@@ -9,19 +9,16 @@ import yfinance as yf
 
 env = Environment(loader=FileSystemLoader(os.path.dirname(os.path.abspath(__file__))))
 
-def format_to_millions(value):
-    print("html_generator 1 format to millions")
-    
 # gate to match Aug 10 rollback
 VERSION = "SEGMENTS v2025-08-10b"
 
-    """
-    Formats a numerical value to a string representing the value in millions
-    with a dollar sign and commas.
-    """
-    print("html generator 1 formatting to millions", value)
+
+def format_to_millions(value):
+    """Format a numeric value into millions with a dollar sign and commas."""
+    print("html_generator 1 format to millions")
     try:
-        print("---value",value)
+        print("html generator 1 formatting to millions", value)
+        print("---value", value)
         # Assume value is already a float representing the total amount (not in millions)
         value_in_millions = value / 1e6  # Convert to millions
         formatted_value = f"${value_in_millions:,.0f}M"


### PR DESCRIPTION
## Summary
- correct mis-indented docstring and restore `VERSION` constant at module level
- clarify `format_to_millions` docstring and retain debug logging

## Testing
- `python main_remote.py` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f2904838833193a9d6b7d61a2732