### PR TITLE
Improve business segment table scaling

### DIFF
--- a/Test/test_choose_scale.py
+++ b/Test/test_choose_scale.py
@@ -1,0 +1,16 @@
+import sys, pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
+from generate_segment_charts import _choose_scale
+
+
+def test_choose_scale_uses_billions_when_small_segments_present():
+    vals = [1.5e12, 2e9, 5e11]
+    div, unit = _choose_scale(vals)
+    assert div == 1e9 and unit == "$B"
+
+
+def test_choose_scale_prefers_trillions_when_all_values_large():
+    vals = [2.1e12, 1.8e12, 1.2e12]
+    div, unit = _choose_scale(vals)
+    assert div == 1e12 and unit == "$T"


### PR DESCRIPTION
## Summary
- Refine segment table scaling logic to avoid tiny decimal values by choosing units based on min/max figures
- Pass full data set to scaling helper and update table generation accordingly
- Add unit tests covering trillion vs. billion selection

## Testing
- `pytest Test/test_choose_scale.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b734fcbeac8331bfe5a88a82293560