### PR TITLE
Add raw segment fact dump for SEC segment data

### DIFF
--- a/generate_segment_charts.py
+++ b/generate_segment_charts.py
@@ -138,7 +138,7 @@ def _last3_plus_ttm(years: List[str]) -> List[str]:
 def generate_segment_charts_for_ticker(ticker: str, out_dir: Path) -> None:
     """Generate charts and a compact pivot HTML table for a single ticker."""
     try:
-        df = get_segment_data(ticker)
+        df = get_segment_data(ticker, dump_raw=True)
     except Exception as fetch_err:
         print(f"[{VERSION}] Error fetching segment data for {ticker}: {fetch_err}")
         ensure_dir(out_dir)

--- a/generate_segment_tables.py
+++ b/generate_segment_tables.py
@@ -112,7 +112,7 @@ def main():
     for i, t in enumerate(TICKERS, start=1):
         try:
             print(f"[{i}/{len(TICKERS)}] fetching {t}…")
-            df = get_segment_data(t)
+            df = get_segment_data(t, dump_raw=True)
             html = render_table_html(t, df)
             out_file = OUTPUT_DIR / f"{t}_segments.html"
             save_html(out_file, html)


### PR DESCRIPTION
## Summary
- capture all revenue and operating income facts regardless of dimension filters
- allow `get_segment_data` to optionally write these raw facts to `charts/{ticker}/{ticker}_segment_raw.txt`
- enable raw fact dumping in segment chart and table generators

## Testing
- `pytest` *(fails: SystemExit: ERROR: export Email='your.sec.address@example.com' first)*

------
https://chatgpt.com/codex/tasks/task_e_68b745a2462c83318051231d30e54537