### PR TITLE
Reorder dividend chart on ticker pages

### DIFF
--- a/html_generator2.py
+++ b/html_generator2.py
@@ -221,6 +221,11 @@ td{padding:4px;border:1px solid #8080FF}
   </div>
 
   <div class="chart-block">
+    <h2>EPS &amp; Dividend</h2>
+    <img class="chart-img chart-block" src="{{ ticker_data.eps_dividend_chart_path }}" alt="EPS & Dividend">
+  </div>
+
+  <div class="chart-block">
     <h2>Valuation</h2>
     <img class="chart-img chart-block" src="{{ ticker_data.valuation_chart }}" alt="Valuation">
     <div class="table-wrap">{{ ticker_data.valuation_info_table | safe }}</div>
@@ -231,11 +236,6 @@ td{padding:4px;border:1px solid #8080FF}
     <h2>Implied Growth</h2>
     <img class="chart-img chart-block" src="{{ ticker_data.implied_growth_chart_path }}" alt="Implied Growth">
     <div class="table-wrap">{{ ticker_data.implied_growth_table_html | safe }}</div>
-  </div>
-
-  <div class="chart-block">
-    <h2>EPS &amp; Dividend</h2>
-    <img class="chart-img chart-block" src="{{ ticker_data.eps_dividend_chart_path }}" alt="EPS & Dividend">
   </div>
 
   <p class="chart-block"><a href="../index.html">← Back</a></p>

--- a/templates/ticker_template.html
+++ b/templates/ticker_template.html
@@ -60,6 +60,11 @@
   </div>
 
   <div class="chart-block">
+    <h2>EPS &amp; Dividend</h2>
+    <img class="chart-img chart-block" src="{{ ticker_data.eps_dividend_chart_path }}" alt="EPS & Dividend">
+  </div>
+
+  <div class="chart-block">
     <h2>Valuation</h2>
     <img class="chart-img chart-block" src="{{ ticker_data.valuation_chart }}" alt="Valuation">
     <div class="table-wrap">{{ ticker_data.valuation_info_table | safe }}</div>
@@ -70,11 +75,6 @@
     <h2>Implied Growth</h2>
     <img class="chart-img chart-block" src="{{ ticker_data.implied_growth_chart_path }}" alt="Implied Growth">
     <div class="table-wrap">{{ ticker_data.implied_growth_table_html | safe }}</div>
-  </div>
-
-  <div class="chart-block">
-    <h2>EPS &amp; Dividend</h2>
-    <img class="chart-img chart-block" src="{{ ticker_data.eps_dividend_chart_path }}" alt="EPS & Dividend">
   </div>
 
   <p class="chart-block"><a href="../index.html">← Back</a></p>


### PR DESCRIPTION
## Summary
- Place EPS & Dividend chart below the Balance Sheet and before Valuation on ticker pages
- Update template generator to reflect new order

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8ed3d300483319f1391932bd6855c