### PR TITLE
Handle multiple segment axes and expose raw data

### DIFF
--- a/generate_segment_charts.py
+++ b/generate_segment_charts.py
@@ -168,104 +168,126 @@ def generate_segment_charts_for_ticker(ticker: str, out_dir: Path) -> None:
     df["Revenue"] = df["Revenue"].map(_to_float)
     df["OpIncome"] = df["OpIncome"].map(_to_float)
 
-    # Item 2 axis ranking (diagnostics only)
     if dump_item2_axis_ranking:
         try:
             dump_item2_axis_ranking(ticker, df)
         except Exception:
             pass
 
-    # Shared y-axis scale
-    all_vals = pd.concat([df["Revenue"].dropna(), df["OpIncome"].dropna()], ignore_index=True)
-    if all_vals.empty:
-        min_y, max_y = 0.0, 0.0
-    else:
-        min_y, max_y = float(all_vals.min()), float(all_vals.max())
-        if min_y > 0: min_y = 0.0
-        if max_y < 0: max_y = 0.0
-    spread = max_y - min_y
-    margin = spread * 0.1 if spread else 1.0
-    min_y_plot, max_y_plot = min_y - margin, max_y + margin
+    axes = sorted(set(df["Axis"].tolist()))
+    if not axes:
+        axes = [""]
 
-    years_all = sort_years(sorted(set(df["Year"].tolist())))
-    years_tbl = _last3_plus_ttm(df["Year"].tolist())
-    segments = sorted(set(df["Segment"].tolist()))
+    for axis_idx, axis_name in enumerate(axes[:2]):
+        axis_df = df[df["Axis"] == axis_name] if axis_name != "" else df
 
-    # Charts
-    for seg in segments:
-        seg_df = df[df["Segment"] == seg]
-        revenues = [seg_df.loc[seg_df["Year"] == y, "Revenue"].sum() for y in years_all]
-        op_incomes = [seg_df.loc[seg_df["Year"] == y, "OpIncome"].sum() for y in years_all]
-        revenues_b = [0.0 if pd.isna(v) else v / 1e9 for v in revenues]
-        op_incomes_b = [0.0 if pd.isna(v) else v / 1e9 for v in op_incomes]
-
-        fig, ax = plt.subplots(figsize=(8, 5))
-        x_indices = list(range(len(years_all)))
-        bar_width = 0.35
-        ax.bar([x - bar_width / 2 for x in x_indices], revenues_b, width=bar_width, label="Revenue")
-        ax.bar([x + bar_width / 2 for x in x_indices], op_incomes_b, width=bar_width, label="Operating Income")
-        ax.set_xticks(x_indices)
-        ax.set_xticklabels(years_all)
-        ax.set_ylim(min_y_plot / 1e9, max_y_plot / 1e9)
-        ax.set_ylabel("Value ($B)")
-        ax.set_title(seg)
-        ax.yaxis.grid(True, linestyle="--", alpha=0.5)
-        ax.legend(loc="upper left")
-        plt.tight_layout()
-        fig_path = out_dir / f"{ticker}_{seg.replace('/', '_').replace(' ', '_')}.png"
-        plt.savefig(fig_path)
-        plt.close(fig)
-
-    # Table
-    def pv(col):
-        p = df[df["Year"].isin(years_tbl)].pivot_table(index="Segment", columns="Year", values=col, aggfunc="sum")
-        return p.reindex(columns=[y for y in years_tbl if y in p.columns])
-
-    rev_p = pv("Revenue")
-    oi_p  = pv("OpIncome")
-
-    sort_col = "TTM" if "TTM" in rev_p.columns else (rev_p.columns[-1] if len(rev_p.columns) else None)
-    if sort_col:
-        rev_p = rev_p.sort_values(by=sort_col, ascending=False)
-        oi_p = oi_p.reindex(index=rev_p.index)
-
-    pct_series = None
-    if "TTM" in rev_p.columns:
-        total_ttm = rev_p["TTM"].sum(skipna=True)
-        if total_ttm and total_ttm != 0:
-            pct_series = (rev_p["TTM"] / total_ttm) * 100.0
-
-    max_val = pd.concat([rev_p, oi_p]).abs().max().max()
-    div, unit = _choose_scale(float(max_val) if pd.notna(max_val) else 0.0)
-
-    cols: List[Tuple[str, str]] = []
-    for y in [c for c in years_tbl if c != "TTM"]:
-        cols += [(y, "Rev"), (y, "OI")]
-    if "TTM" in years_tbl:
-        cols += [("TTM", "Rev"), ("TTM", "OI")]
-
-    out = pd.DataFrame(index=rev_p.index)
-    for (y, kind) in cols:
-        src = rev_p.get(y) if kind == "Rev" else oi_p.get(y)
-        label = f"{y} {'Rev' if kind=='Rev' else 'OI'} ({unit})"
-        out[label] = src
-
-    if pct_series is not None:
-        out["% of Total (TTM)"] = pct_series
-
-    for c in out.columns:
-        if c == "% of Total (TTM)":
-            out[c] = out[c].map(lambda x: f"{float(x):.1f}%" if pd.notnull(x) else "–")
+        all_vals = pd.concat(
+            [axis_df["Revenue"].dropna(), axis_df["OpIncome"].dropna()], ignore_index=True
+        )
+        if all_vals.empty:
+            min_y, max_y = 0.0, 0.0
         else:
-            out[c] = out[c].map(lambda x, d=div, u=unit: _fmt_scaled(x, d, u))
+            min_y, max_y = float(all_vals.min()), float(all_vals.max())
+            if min_y > 0:
+                min_y = 0.0
+            if max_y < 0:
+                max_y = 0.0
+        spread = max_y - min_y
+        margin = spread * 0.1 if spread else 1.0
+        min_y_plot, max_y_plot = min_y - margin, max_y + margin
 
-    for ttm_col in [c for c in out.columns if c.startswith("TTM ")]:
-        out[ttm_col] = out[ttm_col].map(lambda s: f"<strong>{s}</strong>" if s != "–" else s)
+        years_all = sort_years(sorted(set(axis_df["Year"].tolist())))
+        years_tbl = _last3_plus_ttm(axis_df["Year"].tolist())
+        segments = sorted(set(axis_df["Segment"].tolist()))
 
-    out.index.name = "Segment"
-    out_disp = out.reset_index()
+        suffix = "" if axis_idx == 0 else "_axis2"
 
-    css = """
+        for seg in segments:
+            seg_df = axis_df[axis_df["Segment"] == seg]
+            revenues = [seg_df.loc[seg_df["Year"] == y, "Revenue"].sum() for y in years_all]
+            op_incomes = [seg_df.loc[seg_df["Year"] == y, "OpIncome"].sum() for y in years_all]
+            revenues_b = [0.0 if pd.isna(v) else v / 1e9 for v in revenues]
+            op_incomes_b = [0.0 if pd.isna(v) else v / 1e9 for v in op_incomes]
+
+            fig, ax = plt.subplots(figsize=(8, 5))
+            x_indices = list(range(len(years_all)))
+            bar_width = 0.35
+            ax.bar(
+                [x - bar_width / 2 for x in x_indices],
+                revenues_b,
+                width=bar_width,
+                label="Revenue",
+            )
+            ax.bar(
+                [x + bar_width / 2 for x in x_indices],
+                op_incomes_b,
+                width=bar_width,
+                label="Operating Income",
+            )
+            ax.set_xticks(x_indices)
+            ax.set_xticklabels(years_all)
+            ax.set_ylim(min_y_plot / 1e9, max_y_plot / 1e9)
+            ax.set_ylabel("Value ($B)")
+            ax.set_title(seg)
+            ax.yaxis.grid(True, linestyle="--", alpha=0.5)
+            ax.legend(loc="upper left")
+            plt.tight_layout()
+            fig_path = out_dir / f"{ticker}_{seg.replace('/', '_').replace(' ', '_')}{suffix}.png"
+            plt.savefig(fig_path)
+            plt.close(fig)
+
+        def pv(col):
+            p = (
+                axis_df[axis_df["Year"].isin(years_tbl)]
+                .pivot_table(index="Segment", columns="Year", values=col, aggfunc="sum")
+            )
+            return p.reindex(columns=[y for y in years_tbl if y in p.columns])
+
+        rev_p = pv("Revenue")
+        oi_p = pv("OpIncome")
+
+        sort_col = "TTM" if "TTM" in rev_p.columns else (rev_p.columns[-1] if len(rev_p.columns) else None)
+        if sort_col:
+            rev_p = rev_p.sort_values(by=sort_col, ascending=False)
+            oi_p = oi_p.reindex(index=rev_p.index)
+
+        pct_series = None
+        if "TTM" in rev_p.columns:
+            total_ttm = rev_p["TTM"].sum(skipna=True)
+            if total_ttm and total_ttm != 0:
+                pct_series = (rev_p["TTM"] / total_ttm) * 100.0
+
+        max_val = pd.concat([rev_p, oi_p]).abs().max().max()
+        div, unit = _choose_scale(float(max_val) if pd.notna(max_val) else 0.0)
+
+        cols: List[Tuple[str, str]] = []
+        for y in [c for c in years_tbl if c != "TTM"]:
+            cols += [(y, "Rev"), (y, "OI")]
+        if "TTM" in years_tbl:
+            cols += [("TTM", "Rev"), ("TTM", "OI")]
+
+        out_tbl = pd.DataFrame(index=rev_p.index)
+        for (y, kind) in cols:
+            src = rev_p.get(y) if kind == "Rev" else oi_p.get(y)
+            label = f"{y} {'Rev' if kind=='Rev' else 'OI'} ({unit})"
+            out_tbl[label] = src
+
+        if pct_series is not None:
+            out_tbl["% of Total (TTM)"] = pct_series
+
+        for c in out_tbl.columns:
+            if c == "% of Total (TTM)":
+                out_tbl[c] = out_tbl[c].map(lambda x: f"{float(x):.1f}%" if pd.notnull(x) else "–")
+            else:
+                out_tbl[c] = out_tbl[c].map(lambda x, d=div, u=unit: _fmt_scaled(x, d, u))
+
+        for ttm_col in [c for c in out_tbl.columns if c.startswith("TTM ")]:
+            out_tbl[ttm_col] = out_tbl[ttm_col].map(lambda s: f"<strong>{s}</strong>" if s != "–" else s)
+
+        out_tbl.index.name = "Segment"
+        out_disp = out_tbl.reset_index()
+
+        css = """
 <style>
 .table-wrap{overflow:auto; max-width:100%;}
 .segment-pivot { width:100%; border-collapse:collapse; font-family: Arial, sans-serif; font-size:14px; }
@@ -276,28 +298,43 @@ def generate_segment_charts_for_ticker(ticker: str, out_dir: Path) -> None:
 .segment-pivot td { font-variant-numeric: tabular-nums; text-align:right; }
 .segment-pivot td:first-child, .segment-pivot th:first-child { text-align:left; }
 .table-note { font-size:12px; color:#666; margin:6px 0 8px; }
+/* raw-link style for the per-axis table footer */
+.raw-link{margin:6px 0 10px 0;font-size:13px}
+.raw-link a{color:#0066cc;text-decoration:none}
+.raw-link a:hover{text-decoration:underline}
 </style>
 """.strip()
+        stamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
+        caption = (
+            f'<div class="table-note">{VERSION} · {stamp} — Values are shown in a single scale for this table: '
+            f'<b>{unit}</b>. TTM values are <b>bold</b>. “% of Total (TTM)” shows revenue mix.</div>'
+        )
+        html = out_disp.to_html(index=False, escape=False, classes="segment-pivot", border=0)
+        table_content = css + "\n" + caption + f"\n<div class='table-wrap'>{html}</div>"
 
-    stamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
-    caption = (
-        f'<div class="table-note">{VERSION} · {stamp} — Values are shown in a single scale for this table: '
-        f'<b>{unit}</b>. TTM values are <b>bold</b>. “% of Total (TTM)” shows revenue mix.</div>'
-    )
-    html = out_disp.to_html(index=False, escape=False, classes="segment-pivot", border=0)
-    table_content = css + "\n" + caption + f"\n<div class='table-wrap'>{html}</div>"
+        # Append a raw TXT link only for the Business Segments axis.
+        # axis_name holds the raw axis key (e.g., 'us-gaap:StatementBusinessSegmentsAxis').
+        if any(key in str(axis_name) for key in (
+            "StatementBusinessSegmentsAxis", "BusinessSegmentsAxis",
+            "ReportableSegmentsAxis", "OperatingSegmentsAxis"
+        )):
+            raw_rel = f"{ticker}_segment_raw.txt"
+            table_content += (
+                f"\n<div class='raw-link'><a href='{raw_rel}' "
+                f"target='_blank' rel='noopener'>Raw segment data</a></div>"
+            )
 
-    out_path = out_dir / f"{ticker}_segments_table.html"
-    try:
-        out_path.unlink(missing_ok=True)
-    except Exception:
-        pass
-    out_path.write_text(table_content, encoding="utf-8")
-    print(f"[{VERSION}] writing table → {out_path}")
-    try:
-        print(f"[{VERSION}] wrote {out_path.stat().st_size} bytes")
-    except Exception:
-        pass
+        out_path = out_dir / f"{ticker}_segments_table{suffix}.html"
+        try:
+            out_path.unlink(missing_ok=True)
+        except Exception:
+            pass
+        out_path.write_text(table_content, encoding="utf-8")
+        print(f"[{VERSION}] writing table → {out_path}")
+        try:
+            print(f"[{VERSION}] wrote {out_path.stat().st_size} bytes")
+        except Exception:
+            pass
 
 # ─────────────────────────── CLI wrapper ───────────────────────────
 

--- a/html_generator2.py
+++ b/html_generator2.py
@@ -47,19 +47,23 @@ def inject_retro(html: str) -> str:
     return html
 
 # ───────── segment helpers ──────────────────────────────────────
-def build_segment_carousel_html(ticker: str, charts_dir_fs: str, charts_dir_web: str) -> str:
-    """
-    Carousel shows ALL PNGs in charts/<ticker>/*.png
-    """
+def build_segment_carousel_html(
+    ticker: str, charts_dir_fs: str, charts_dir_web: str, axis: int = 1
+) -> str:
+    """Return carousel HTML for a given axis (1 or 2)."""
     seg_dir = os.path.join(charts_dir_fs, ticker)
     if not os.path.isdir(seg_dir):
         return ""
     pngs = [f for f in sorted(os.listdir(seg_dir)) if f.lower().endswith(".png")]
+    if axis == 1:
+        pngs = [f for f in pngs if "_axis2" not in f.lower()]
+    else:
+        pngs = [f for f in pngs if "_axis2" in f.lower()]
     if not pngs:
         return ""
     items = []
     for f in pngs:
-        src = f"{charts_dir_web}/{ticker}/{f}"  # web path for /pages/*
+        src = f"{charts_dir_web}/{ticker}/{f}"
         items.append(f'<div class="carousel-item"><img class="chart-img" src="{src}" alt="{f}"></div>')
     return '<div class="carousel-container chart-block">\n' + "\n".join(items) + "\n</div>"
 
@@ -377,6 +381,7 @@ def prepare_and_generate_ticker_pages(tickers, charts_dir_fs="charts"):
                 "unmapped_expense_html":         get_file_or_placeholder(f"{charts_dir_fs}/{t}_unmapped_fields.html", "No unmapped expenses."),
                 "implied_growth_table_html":     get_file_or_placeholder(f"{charts_dir_fs}/{t}_implied_growth_summary.html", "No implied growth data available."),
                 "segment_table_html":            get_file_or_placeholder(f"{charts_dir_fs}/{t}/{t}_segments_table.html", "No segment data available."),
+                "segment2_table_html":           get_file_or_placeholder(f"{charts_dir_fs}/{t}/{t}_segments_table_axis2.html", ""),
 
                 # Images (web paths)
                 "revenue_net_income_chart_path": f"{charts_dir_web}/{t}_revenue_net_income_chart.png",
@@ -393,7 +398,8 @@ def prepare_and_generate_ticker_pages(tickers, charts_dir_fs="charts"):
                 "implied_growth_chart_path":     f"{charts_dir_web}/{t}_implied_growth_plot.png",
 
                 # Segment carousel
-                "segment_carousel_html":         build_segment_carousel_html(t, charts_dir_fs, charts_dir_web),
+                "segment_carousel_html":         build_segment_carousel_html(t, charts_dir_fs, charts_dir_web, axis=1),
+                "segment2_carousel_html":        build_segment_carousel_html(t, charts_dir_fs, charts_dir_web, axis=2),
             }
             rendered = env.get_template("ticker_template.html").render(ticker_data=d)
             with open(f"pages/{t}_page.html", "w", encoding="utf-8") as f:

--- a/sec_segment_data_arelle.py
+++ b/sec_segment_data_arelle.py
@@ -108,8 +108,8 @@ OPINC_TAGS = [
     "us-gaap:OperatingIncomeLoss",
 ]
 
-# Regex helpers
-_SEGMENT_DIM_RE = re.compile(r"segment", re.IGNORECASE)
+# Regex helpers – broaden to pick up geographic and product/service axes
+_SEGMENT_DIM_RE = re.compile(r"segment|geograph|product|service", re.IGNORECASE)
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -277,15 +277,6 @@ def parse_ixbrl_segments(ix_path: Path) -> Tuple[pd.DataFrame, str, str]:
                 if not any(_SEGMENT_DIM_RE.search(d) for d in dims.keys()):
                     continue
 
-                # choose the first member that looks like a business segment
-                segment_label = None
-                for dim_qn, mem_qn in dims.items():
-                    if _SEGMENT_DIM_RE.search(dim_qn) and mem_qn:
-                        segment_label = mem_qn.split(":")[-1]  # human-ish fallback
-                        break
-                if not segment_label:
-                    continue
-
                 val = _scale_and_sign(
                     fact.text,
                     fact.get("decimals"),
@@ -295,11 +286,16 @@ def parse_ixbrl_segments(ix_path: Path) -> Tuple[pd.DataFrame, str, str]:
                 if val is None:
                     continue
 
-                rows.append({
-                    "Segment": segment_label,
-                    "PeriodEnd": ctx["period_end"],
-                    "Value": val,
-                })
+                for dim_qn, mem_qn in dims.items():
+                    if _SEGMENT_DIM_RE.search(dim_qn) and mem_qn:
+                        axis_label = dim_qn.split(":")[-1]
+                        segment_label = mem_qn.split(":")[-1]
+                        rows.append({
+                            "Axis": axis_label,
+                            "Segment": segment_label,
+                            "PeriodEnd": ctx["period_end"],
+                            "Value": val,
+                        })
 
             if rows:
                 break  # stop at first concept that produced usable facts
@@ -314,17 +310,25 @@ def parse_ixbrl_segments(ix_path: Path) -> Tuple[pd.DataFrame, str, str]:
     op_df, op_used = collect(OPINC_TAGS)
 
     if rev_df.empty and op_df.empty:
-        return pd.DataFrame(columns=["Segment", "PeriodEnd", "Revenue", "OpIncome"]), rev_used, op_used
+        return pd.DataFrame(columns=["Axis", "Segment", "PeriodEnd", "Revenue", "OpIncome"]), rev_used, op_used
 
-    # sum by segment + period
-    rev_g = rev_df.groupby(["Segment", "PeriodEnd"], as_index=False)["Value"].sum() if not rev_df.empty else pd.DataFrame(columns=["Segment", "PeriodEnd", "Value"])
+    # sum by axis + segment + period
+    rev_g = (
+        rev_df.groupby(["Axis", "Segment", "PeriodEnd"], as_index=False)["Value"].sum()
+        if not rev_df.empty
+        else pd.DataFrame(columns=["Axis", "Segment", "PeriodEnd", "Value"])
+    )
     rev_g.rename(columns={"Value": "Revenue"}, inplace=True)
 
-    op_g = op_df.groupby(["Segment", "PeriodEnd"], as_index=False)["Value"].sum() if not op_df.empty else pd.DataFrame(columns=["Segment", "PeriodEnd", "Value"])
+    op_g = (
+        op_df.groupby(["Axis", "Segment", "PeriodEnd"], as_index=False)["Value"].sum()
+        if not op_df.empty
+        else pd.DataFrame(columns=["Axis", "Segment", "PeriodEnd", "Value"])
+    )
     op_g.rename(columns={"Value": "OpIncome"}, inplace=True)
 
-    df = pd.merge(rev_g, op_g, on=["Segment", "PeriodEnd"], how="outer")
-    df = df.sort_values(["PeriodEnd", "Segment"]).reset_index(drop=True)
+    df = pd.merge(rev_g, op_g, on=["Axis", "Segment", "PeriodEnd"], how="outer")
+    df = df.sort_values(["Axis", "PeriodEnd", "Segment"]).reset_index(drop=True)
     return df, (rev_used or ""), (op_used or "")
 
 
@@ -379,17 +383,16 @@ def collect_all_segment_facts(ix_path: Path) -> pd.DataFrame:
 
 def compute_segment_ttm(fy_df: pd.DataFrame, q_df: pd.DataFrame) -> pd.DataFrame:
     """
-    TTM ≈ latest FY + latest Q - same Q of prior FY, per segment.
+    TTM ≈ latest FY + latest Q - same Q of prior FY, per segment/axis.
     Requires PeriodEnd present (use before dropping it).
     """
     if fy_df.empty or q_df.empty:
-        return pd.DataFrame(columns=["Segment", "Year", "Revenue", "OpIncome"])
+        return pd.DataFrame(columns=["Axis", "Segment", "Year", "Revenue", "OpIncome"])
 
     latest_q_date = q_df["PeriodEnd"].max()
     if pd.isna(latest_q_date):
-        return pd.DataFrame(columns=["Segment", "Year", "Revenue", "OpIncome"])
+        return pd.DataFrame(columns=["Axis", "Segment", "Year", "Revenue", "OpIncome"])
 
-    # derive “same quarter last year” by month/day offset of ~1 year
     prior_year_same_q_date = latest_q_date.replace(year=latest_q_date.year - 1)
 
     fy_last = fy_df[fy_df["PeriodEnd"] == fy_df["PeriodEnd"].max()]
@@ -398,15 +401,16 @@ def compute_segment_ttm(fy_df: pd.DataFrame, q_df: pd.DataFrame) -> pd.DataFrame
 
     def _sum_cols(g: pd.DataFrame) -> pd.DataFrame:
         if g.empty:
-            return pd.DataFrame(columns=["Segment", "Revenue", "OpIncome"])
-        s = g.groupby("Segment", as_index=False)[["Revenue", "OpIncome"]].sum()
+            return pd.DataFrame(columns=["Axis", "Segment", "Revenue", "OpIncome"])
+        s = g.groupby(["Axis", "Segment"], as_index=False)[["Revenue", "OpIncome"]].sum()
         return s
 
-    ttm = _sum_cols(fy_last).merge(_sum_cols(q_latest), on="Segment", how="outer", suffixes=("_FY", "_Q"))
-    ttm = ttm.merge(_sum_cols(q_prev), on="Segment", how="left")
+    ttm = _sum_cols(fy_last).merge(
+        _sum_cols(q_latest), on=["Axis", "Segment"], how="outer", suffixes=("_FY", "_Q")
+    )
+    ttm = ttm.merge(_sum_cols(q_prev), on=["Axis", "Segment"], how="left")
     ttm.rename(columns={"Revenue": "Revenue_prevQ", "OpIncome": "OpIncome_prevQ"}, inplace=True)
 
-    # Fill NaNs with 0 for arithmetic
     for col in ["Revenue_FY", "OpIncome_FY", "Revenue_Q", "OpIncome_Q", "Revenue_prevQ", "OpIncome_prevQ"]:
         if col in ttm.columns:
             ttm[col] = ttm[col].fillna(0.0)
@@ -414,14 +418,14 @@ def compute_segment_ttm(fy_df: pd.DataFrame, q_df: pd.DataFrame) -> pd.DataFrame
     ttm["Revenue"] = ttm["Revenue_FY"] + ttm["Revenue_Q"] - ttm["Revenue_prevQ"]
     ttm["OpIncome"] = ttm["OpIncome_FY"] + ttm["OpIncome_Q"] - ttm["OpIncome_prevQ"]
     ttm["Year"] = "TTM"
-    return ttm[["Segment", "Year", "Revenue", "OpIncome"]]
+    return ttm[["Axis", "Segment", "Year", "Revenue", "OpIncome"]]
 
 
 def get_segment_data(ticker: str, dump_raw: bool = False) -> pd.DataFrame:
     """
     Public API:
       Input: ticker (e.g., 'AAPL')
-      Output: DataFrame with columns: Segment, Year (yyyy or 'TTM'), Revenue, OpIncome
+      Output: DataFrame with columns: Axis, Segment, Year (yyyy or 'TTM'), Revenue, OpIncome
       df.attrs['revenue_concept'], df.attrs['op_income_concept'] record concept choices.
 
       If ``dump_raw`` is True, a text file with all unfiltered facts for revenue
@@ -438,8 +442,8 @@ def get_segment_data(ticker: str, dump_raw: bool = False) -> pd.DataFrame:
 
     # Download iXBRL HTMLs and parse
     with pd.option_context("display.width", 200):
-        k_df = pd.DataFrame(columns=["Segment", "PeriodEnd", "Revenue", "OpIncome"])
-        q_df = pd.DataFrame(columns=["Segment", "PeriodEnd", "Revenue", "OpIncome"])
+        k_df = pd.DataFrame(columns=["Axis", "Segment", "PeriodEnd", "Revenue", "OpIncome"])
+        q_df = pd.DataFrame(columns=["Axis", "Segment", "PeriodEnd", "Revenue", "OpIncome"])
 
         if ten_k:
             url_k = build_filing_url(cik, ten_k["accession"], ten_k["document"])
@@ -482,7 +486,7 @@ def get_segment_data(ticker: str, dump_raw: bool = False) -> pd.DataFrame:
 
     # bail out gracefully if nothing
     if k_df.empty and q_df.empty:
-        df = pd.DataFrame(columns=["Segment", "Year", "Revenue", "OpIncome"])
+        df = pd.DataFrame(columns=["Axis", "Segment", "Year", "Revenue", "OpIncome"])
         df.attrs["revenue_concept"] = rev_used
         df.attrs["op_income_concept"] = op_used
         return df
@@ -502,7 +506,7 @@ def get_segment_data(ticker: str, dump_raw: bool = False) -> pd.DataFrame:
     def _roll(df: pd.DataFrame) -> pd.DataFrame:
         if df.empty:
             return df
-        g = df.groupby(["Segment", "PeriodEnd"], as_index=False)[["Revenue", "OpIncome"]].sum()
+        g = df.groupby(["Axis", "Segment", "PeriodEnd"], as_index=False)[["Revenue", "OpIncome"]].sum()
         g["Year"] = g["PeriodEnd"].dt.year
         return g
 
@@ -512,22 +516,26 @@ def get_segment_data(ticker: str, dump_raw: bool = False) -> pd.DataFrame:
     # Keep last 3 fiscal-year ends from 10-K side (if present), else from 10-Q
     source_for_years = k_roll if not k_roll.empty else q_roll
     years = sorted(source_for_years["Year"].unique())[-3:] if not source_for_years.empty else []
-    fy = source_for_years[source_for_years["Year"].isin(years)][["Segment", "Year", "Revenue", "OpIncome"]].copy()
+    fy = source_for_years[source_for_years["Year"].isin(years)][["Axis", "Segment", "Year", "Revenue", "OpIncome"]].copy()
 
     # Compute TTM if we have both annual + quarterly dates
-    ttm = compute_segment_ttm(k_df if not k_df.empty else q_df, q_df) if not q_df.empty else pd.DataFrame(columns=["Segment", "Year", "Revenue", "OpIncome"])
+    ttm = compute_segment_ttm(k_df if not k_df.empty else q_df, q_df) if not q_df.empty else pd.DataFrame(columns=["Axis", "Segment", "Year", "Revenue", "OpIncome"])
 
     out = pd.concat([fy, ttm], ignore_index=True)
     if out.empty:
-        out = pd.DataFrame(columns=["Segment", "Year", "Revenue", "OpIncome"])
+        out = pd.DataFrame(columns=["Axis", "Segment", "Year", "Revenue", "OpIncome"])
     else:
-        # Sum duplicates (same Segment-Year) just in case
-        out = out.groupby(["Segment", "Year"], as_index=False)[["Revenue", "OpIncome"]].sum()
-        # Order nicely: latest first, TTM at bottom
+        # Sum duplicates (same Axis-Segment-Year) just in case
+        out = out.groupby(["Axis", "Segment", "Year"], as_index=False)[["Revenue", "OpIncome"]].sum()
+        # Order nicely: Axis, latest first, TTM at bottom
         def _yrkey(y):
             return 9999 if y == "TTM" else int(y)
         out["__k"] = out["Year"].map(_yrkey)
-        out = out.sort_values(["__k", "Segment"], ascending=[False, True]).drop(columns="__k").reset_index(drop=True)
+        out = (
+            out.sort_values(["Axis", "__k", "Segment"], ascending=[True, False, True])
+            .drop(columns="__k")
+            .reset_index(drop=True)
+        )
 
     out.attrs["revenue_concept"] = rev_used
     out.attrs["op_income_concept"] = op_used

--- a/templates/ticker_template.html
+++ b/templates/ticker_template.html
@@ -50,6 +50,14 @@
         {{ ticker_data.segment_table_html | safe }}
       </div>
     </div>
+    {% if ticker_data.segment2_carousel_html %}
+    {{ ticker_data.segment2_carousel_html | safe }}
+    <div class="segment-table-wrapper">
+      <div class="table-wrap">
+        {{ ticker_data.segment2_table_html | safe }}
+      </div>
+    </div>
+    {% endif %}
   </div>
   {% endif %}
 


### PR DESCRIPTION
## Summary
- support geographic and product segment axes by broadening axis detection and storing axis info
- generate separate charts and tables for up to two segment axes and link raw data within the Business Segments table
- update templates and HTML generator to display second axis carousel/table and remove redundant raw-data link

## Testing
- `python -m py_compile sec_segment_data_arelle.py generate_segment_charts.py html_generator2.py`


------
https://chatgpt.com/codex/tasks/task_e_68b98438b5fc8331ad7f9f5ec0de28b6