### PR TITLE
Handle multiple segment axes and hide empty operating income

### DIFF
--- a/html_generator2.py
+++ b/html_generator2.py
@@ -47,19 +47,23 @@ def inject_retro(html: str) -> str:
     return html
 
 # ───────── segment helpers ──────────────────────────────────────
-def build_segment_carousel_html(ticker: str, charts_dir_fs: str, charts_dir_web: str) -> str:
-    """
-    Carousel shows ALL PNGs in charts/<ticker>/*.png
-    """
+def build_segment_carousel_html(
+    ticker: str, charts_dir_fs: str, charts_dir_web: str, axis: int = 1
+) -> str:
+    """Return carousel HTML for a given axis (1 or 2)."""
     seg_dir = os.path.join(charts_dir_fs, ticker)
     if not os.path.isdir(seg_dir):
         return ""
     pngs = [f for f in sorted(os.listdir(seg_dir)) if f.lower().endswith(".png")]
+    if axis == 1:
+        pngs = [f for f in pngs if "_axis2" not in f.lower()]
+    else:
+        pngs = [f for f in pngs if "_axis2" in f.lower()]
     if not pngs:
         return ""
     items = []
     for f in pngs:
-        src = f"{charts_dir_web}/{ticker}/{f}"  # web path for /pages/*
+        src = f"{charts_dir_web}/{ticker}/{f}"
         items.append(f'<div class="carousel-item"><img class="chart-img" src="{src}" alt="{f}"></div>')
     return '<div class="carousel-container chart-block">\n' + "\n".join(items) + "\n</div>"
 
@@ -377,6 +381,7 @@ def prepare_and_generate_ticker_pages(tickers, charts_dir_fs="charts"):
                 "unmapped_expense_html":         get_file_or_placeholder(f"{charts_dir_fs}/{t}_unmapped_fields.html", "No unmapped expenses."),
                 "implied_growth_table_html":     get_file_or_placeholder(f"{charts_dir_fs}/{t}_implied_growth_summary.html", "No implied growth data available."),
                 "segment_table_html":            get_file_or_placeholder(f"{charts_dir_fs}/{t}/{t}_segments_table.html", "No segment data available."),
+                "segment2_table_html":           get_file_or_placeholder(f"{charts_dir_fs}/{t}/{t}_segments_table_axis2.html", ""),
 
                 # Images (web paths)
                 "revenue_net_income_chart_path": f"{charts_dir_web}/{t}_revenue_net_income_chart.png",
@@ -393,7 +398,8 @@ def prepare_and_generate_ticker_pages(tickers, charts_dir_fs="charts"):
                 "implied_growth_chart_path":     f"{charts_dir_web}/{t}_implied_growth_plot.png",
 
                 # Segment carousel
-                "segment_carousel_html":         build_segment_carousel_html(t, charts_dir_fs, charts_dir_web),
+                "segment_carousel_html":         build_segment_carousel_html(t, charts_dir_fs, charts_dir_web, axis=1),
+                "segment2_carousel_html":        build_segment_carousel_html(t, charts_dir_fs, charts_dir_web, axis=2),
             }
             rendered = env.get_template("ticker_template.html").render(ticker_data=d)
             with open(f"pages/{t}_page.html", "w", encoding="utf-8") as f:

--- a/templates/ticker_template.html
+++ b/templates/ticker_template.html
@@ -50,6 +50,14 @@
         {{ ticker_data.segment_table_html | safe }}
       </div>
     </div>
+    {% if ticker_data.segment2_carousel_html %}
+    {{ ticker_data.segment2_carousel_html | safe }}
+    <div class="segment-table-wrapper">
+      <div class="table-wrap">
+        {{ ticker_data.segment2_table_html | safe }}
+      </div>
+    </div>
+    {% endif %}
   </div>
   {% endif %}
 


### PR DESCRIPTION
## Summary
- Tag segment dimensions with product/geography AxisGroup and propagate through trailing-twelve-month aggregation
- Generate separate carousels/tables for product and geography axes and skip plotting operating income when data is absent

## Testing
- `python -m py_compile sec_segment_data_arelle.py generate_segment_charts.py html_generator2.py`
- `python generate_segment_charts.py --tickers_csv temp_tickers.csv --output_dir charts_test` *(fails: HTTPSConnectionPool(host='data.sec.gov', port=443): Max retries exceeded with url...)*

------
https://chatgpt.com/codex/tasks/task_e_68b98438b5fc8331ad7f9f5ec0de28b6