### PR TITLE
feat: split segment outputs by axis

### DIFF
--- a/main_remote.py
+++ b/main_remote.py
@@ -134,12 +134,16 @@ def build_segments_for_ticker(ticker: str) -> bool:
     out_dir = Path(CHARTS_DIR) / ticker
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    # 1) Charts (+ canonical table emitted by generate_segment_charts_for_ticker)
+    # 1) Charts (+ tables emitted by generate_segment_charts_for_ticker)
     generate_segment_charts_for_ticker(ticker, out_dir)
 
-    # 2) No second writer call. We only normalize/verify file presence below.
-    canonical = out_dir / f"{ticker}_segments_table.html"
-    return canonical.exists() and canonical.is_file()
+    axis1 = out_dir / f"axis1_{ticker}_segments_table.html"
+    axis2 = out_dir / f"axis2_{ticker}_segments_table.html"
+    ok1 = axis1.exists() and axis1.is_file()
+    ok2 = axis2.exists() and axis2.is_file()
+    if not ok1 or not ok2:
+        print(f"[segments] Missing segment tables for {ticker}: axis1={ok1} axis2={ok2}")
+    return ok1 and ok2
 
 # ───────────────────────────────────────────────────────────
 # Main

--- a/templates/ticker_template.html
+++ b/templates/ticker_template.html
@@ -41,13 +41,24 @@
     <div class="table-wrap">{{ ticker_data.unmapped_expense_html | safe }}</div>
   </div>
 
-  {% if ticker_data.segment_carousel_html %}
+  {% if ticker_data.segment_carousel_html_axis1 %}
   <div class="chart-block">
-    <h2>Segment Performance</h2>
-    {{ ticker_data.segment_carousel_html | safe }}
+    <h2>Segment Performance (Axis 1)</h2>
+    {{ ticker_data.segment_carousel_html_axis1 | safe }}
     <div class="segment-table-wrapper">
       <div class="table-wrap">
-        {{ ticker_data.segment_table_html | safe }}
+        {{ ticker_data.segment_table_html_axis1 | safe }}
+      </div>
+    </div>
+  </div>
+  {% endif %}
+  {% if ticker_data.segment_carousel_html_axis2 %}
+  <div class="chart-block">
+    <h2>Segment Performance (Axis 2)</h2>
+    {{ ticker_data.segment_carousel_html_axis2 | safe }}
+    <div class="segment-table-wrapper">
+      <div class="table-wrap">
+        {{ ticker_data.segment_table_html_axis2 | safe }}
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- retain XBRL axis type in segment parser and final data
- generate segment charts/tables per axis using `axis1_`/`axis2_` prefixes
- render separate carousels and tables for each axis on ticker pages and verify both exist during build

## Testing
- `python -m py_compile sec_segment_data_arelle.py generate_segment_charts.py html_generator2.py main_remote.py`
- `python -m py_compile generate_segment_charts.py`

------
https://chatgpt.com/codex/tasks/task_e_68b9a88405d08331a5f224f08cf4b361