### PR TITLE
Handle missing segment table errors gracefully

### DIFF
--- a/main_remote.py
+++ b/main_remote.py
@@ -190,7 +190,8 @@ def mini_main():
                 continue
 
         if missing_segments:
-            raise RuntimeError("Missing segment tables for: " + ", ".join(missing_segments))
+            msg = "Missing segment tables for: " + ", ".join(missing_segments)
+            print(f"[WARN] {msg}")
 
         eps_dividend_generator()
         generate_all_summaries()


### PR DESCRIPTION
## Summary
- Avoid raising a runtime error when segment tables are missing
- Log a warning with the tickers that lack segment tables

## Testing
- `python -m pytest Test/test_segment_parser.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9c8e35a1c83319071cb0526666821