### PR TITLE
Clean up stale segment axis charts before regeneration

### DIFF
--- a/generate_segment_charts.py
+++ b/generate_segment_charts.py
@@ -156,6 +156,17 @@ def generate_segment_charts_for_ticker(ticker: str, out_dir: Path) -> None:
 
     ensure_dir(out_dir)
 
+    # Remove any pre-existing axis1/axis2 charts or tables so outdated
+    # images don't linger when segment compositions change. This ensures
+    # the carousel only shows freshly generated charts for the current
+    # axis breakdown.
+    for pattern in ("axis1_*", "axis2_*"):
+        for old_file in out_dir.glob(pattern):
+            try:
+                old_file.unlink()
+            except Exception:
+                pass
+
     if df is None or df.empty:
         (out_dir / f"{ticker}_segments_table.html").write_text(
             f"<p>No segment data available for {ticker}.</p>", encoding="utf-8"


### PR DESCRIPTION
## Summary
- Delete existing axis1/axis2 chart and table files before regenerating segment charts to prevent stale images from appearing in carousels.

## Testing
- `python -m py_compile generate_segment_charts.py`
- `python Test/test_segment_parser.py` *(failed: HTTPSConnectionPool(host='data.sec.gov', port=443): Max retries exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ef4340248331b267daf2452cf683