### PR TITLE
Remove extra Segment Performance heading

### DIFF
--- a/html_generator2.py
+++ b/html_generator2.py
@@ -223,7 +223,7 @@ td{padding:4px;border:1px solid #8080FF}
 
   {% if ticker_data.segment_carousel_html_axis1 %}
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     {{ ticker_data.segment_carousel_html_axis1 | safe }}
     <div class="segment-table-wrapper">
       <div class="table-wrap">
@@ -234,7 +234,6 @@ td{padding:4px;border:1px solid #8080FF}
   {% endif %}
   {% if ticker_data.segment_carousel_html_axis2 %}
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     {{ ticker_data.segment_carousel_html_axis2 | safe }}
     <div class="segment-table-wrapper">
       <div class="table-wrap">

--- a/pages/AAL_page.html
+++ b/pages/AAL_page.html
@@ -361,7 +361,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/AAL/axis1_AAL_Cargo_And_Freight_Member.png" alt="axis1_AAL_Cargo_And_Freight_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/AAL/axis1_AAL_Loyalty_Program_Marketing_Services_Member.png" alt="axis1_AAL_Loyalty_Program_Marketing_Services_Member.png"></div>

--- a/pages/AAPL_page.html
+++ b/pages/AAPL_page.html
@@ -361,7 +361,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/AAPL/axis1_AAPL_I_Pad_Member.png" alt="axis1_AAPL_I_Pad_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/AAPL/axis1_AAPL_I_Phone_Member.png" alt="axis1_AAPL_I_Phone_Member.png"></div>
@@ -480,7 +480,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/AAPL/axis2_AAPL_Americas.png" alt="axis2_AAPL_Americas.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/AAPL/axis2_AAPL_Europe.png" alt="axis2_AAPL_Europe.png"></div>

--- a/pages/ABBV_page.html
+++ b/pages/ABBV_page.html
@@ -346,7 +346,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/ABBV/axis1_ABBV_Aesthetics_Member.png" alt="axis1_ABBV_Aesthetics_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/ABBV/axis1_ABBV_Eye_Care_Member.png" alt="axis1_ABBV_Eye_Care_Member.png"></div>
@@ -465,7 +465,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/ABBV/axis2_ABBV_Alphagan_Combigan_Member.png" alt="axis2_ABBV_Alphagan_Combigan_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/ABBV/axis2_ABBV_Botox_Cosmetic_Member.png" alt="axis2_ABBV_Botox_Cosmetic_Member.png"></div>

--- a/pages/ADBE_page.html
+++ b/pages/ADBE_page.html
@@ -353,7 +353,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/ADBE/axis1_ADBE_Product_Member.png" alt="axis1_ADBE_Product_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/ADBE/axis1_ADBE_Service_Other_Member.png" alt="axis1_ADBE_Service_Other_Member.png"></div>
@@ -433,7 +433,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/ADBE/axis2_ADBE_Digital_Experience_Member.png" alt="axis2_ADBE_Digital_Experience_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/ADBE/axis2_ADBE_Digital_Media_Member.png" alt="axis2_ADBE_Digital_Media_Member.png"></div>

--- a/pages/AMAT_page.html
+++ b/pages/AMAT_page.html
@@ -360,7 +360,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/AMAT/axis1_AMAT_Applied_Global_Services.png" alt="axis1_AMAT_Applied_Global_Services.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/AMAT/axis1_AMAT_Applied_Global_Services_Member.png" alt="axis1_AMAT_Applied_Global_Services_Member.png"></div>
@@ -479,7 +479,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/AMAT/AMAT_Asia_Pacific_Member_axis2.png" alt="AMAT_Asia_Pacific_Member_axis2.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/AMAT/AMAT_C_N_axis2.png" alt="AMAT_C_N_axis2.png"></div>

--- a/pages/AMD_page.html
+++ b/pages/AMD_page.html
@@ -361,7 +361,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/AMD/axis1_AMD_Client_Member.png" alt="axis1_AMD_Client_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/AMD/axis1_AMD_Gaming_Member.png" alt="axis1_AMD_Gaming_Member.png"></div>
@@ -410,7 +410,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/AMD/axis2_AMD_All_Other_Member.png" alt="axis2_AMD_All_Other_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/AMD/axis2_AMD_Client_And_Gaming_Member.png" alt="axis2_AMD_Client_And_Gaming_Member.png"></div>

--- a/pages/AMZN_page.html
+++ b/pages/AMZN_page.html
@@ -372,7 +372,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/AMZN/axis1_AMZN_Advertising_Member.png" alt="axis1_AMZN_Advertising_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/AMZN/axis1_AMZN_Advertising_Services_Member.png" alt="axis1_AMZN_Advertising_Services_Member.png"></div>
@@ -543,7 +543,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/AMZN/axis2_AMZN_Amazon_Web_Services.png" alt="axis2_AMZN_Amazon_Web_Services.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/AMZN/axis2_AMZN_International.png" alt="axis2_AMZN_International.png"></div>

--- a/pages/AVGO_page.html
+++ b/pages/AVGO_page.html
@@ -330,7 +330,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/AVGO/axis1_AVGO_Product_Member.png" alt="axis1_AVGO_Product_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/AVGO/axis1_AVGO_Subscriptionsand_Services_Member.png" alt="axis1_AVGO_Subscriptionsand_Services_Member.png"></div>
@@ -397,7 +397,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/AVGO/axis2_AVGO_Infrastructure_Software_Member.png" alt="axis2_AVGO_Infrastructure_Software_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/AVGO/axis2_AVGO_Semiconductor_Solutions_Member.png" alt="axis2_AVGO_Semiconductor_Solutions_Member.png"></div>

--- a/pages/AXP_page.html
+++ b/pages/AXP_page.html
@@ -372,7 +372,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/AXP/axis1_AXP_Commercial_Services.png" alt="axis1_AXP_Commercial_Services.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/AXP/axis1_AXP_Global_Merchant_And_Network_Services.png" alt="axis1_AXP_Global_Merchant_And_Network_Services.png"></div>

--- a/pages/BA_page.html
+++ b/pages/BA_page.html
@@ -372,7 +372,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/BA/axis1_BA_Boeing_Defense_Space_Security.png" alt="axis1_BA_Boeing_Defense_Space_Security.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/BA/axis1_BA_Commercial_Airplanes.png" alt="axis1_BA_Commercial_Airplanes.png"></div>
@@ -452,7 +452,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/BA/BA_Asia_Member_axis2.png" alt="BA_Asia_Member_axis2.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/BA/BA_Europe_Member_axis2.png" alt="BA_Europe_Member_axis2.png"></div>

--- a/pages/BRK-B_page.html
+++ b/pages/BRK-B_page.html
@@ -387,7 +387,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/BRK-B/axis1_BRK-B_Auto_Sales_Member.png" alt="axis1_BRK-B_Auto_Sales_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/BRK-B/axis1_BRK-B_Consumer_Products_Member.png" alt="axis1_BRK-B_Consumer_Products_Member.png"></div>
@@ -545,7 +545,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/BRK-B/axis2_BRK-B_Berkshire_Hathaway_Energy_Company_Member.png" alt="axis2_BRK-B_Berkshire_Hathaway_Energy_Company_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/BRK-B/axis2_BRK-B_Burlington_Northern_Santa_Fe_Corporation_Member.png" alt="axis2_BRK-B_Burlington_Northern_Santa_Fe_Corporation_Member.png"></div>

--- a/pages/BYND_page.html
+++ b/pages/BYND_page.html
@@ -377,7 +377,7 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/BYND/BYND_Non_Us_Member_axis2.png" alt="BYND_Non_Us_Member_axis2.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/BYND/BYND_U_S_axis2.png" alt="BYND_U_S_axis2.png"></div>

--- a/pages/CCL_page.html
+++ b/pages/CCL_page.html
@@ -326,7 +326,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/CCL/axis1_CCL_Cruise_Onboard_And_Other_Member.png" alt="axis1_CCL_Cruise_Onboard_And_Other_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/CCL/axis1_CCL_Cruise_Passenger_Ticket_Member.png" alt="axis1_CCL_Cruise_Passenger_Ticket_Member.png"></div>
@@ -393,7 +393,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/CCL/axis2_CCL_Cruise_Member.png" alt="axis2_CCL_Cruise_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/CCL/axis2_CCL_Europe.png" alt="axis2_CCL_Europe.png"></div>

--- a/pages/CELH_page.html
+++ b/pages/CELH_page.html
@@ -373,7 +373,7 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/CELH/CELH_Asia_Pacific_Member_axis2.png" alt="CELH_Asia_Pacific_Member_axis2.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/CELH/CELH_Europe_Member_axis2.png" alt="CELH_Europe_Member_axis2.png"></div>

--- a/pages/CMG_page.html
+++ b/pages/CMG_page.html
@@ -358,7 +358,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/CMG/axis1_CMG_Delivery_Service_Member.png" alt="axis1_CMG_Delivery_Service_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/CMG/axis1_CMG_Food_And_Beverage_Member.png" alt="axis1_CMG_Food_And_Beverage_Member.png"></div>
@@ -425,7 +425,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/CMG/CMG_U._S._axis2.png" alt="CMG_U._S._axis2.png"></div>
 </div>

--- a/pages/COIN_page.html
+++ b/pages/COIN_page.html
@@ -394,7 +394,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/COIN/axis1_COIN_Bank_Servicing_Consumer_Net_Member.png" alt="axis1_COIN_Bank_Servicing_Consumer_Net_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/COIN/axis1_COIN_Bank_Servicing_Institutional_Member.png" alt="axis1_COIN_Bank_Servicing_Institutional_Member.png"></div>

--- a/pages/COST_page.html
+++ b/pages/COST_page.html
@@ -320,7 +320,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/COST/axis1_COST_Foodand_Sundries_Member.png" alt="axis1_COST_Foodand_Sundries_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/COST/axis1_COST_Foods_And_Sundries_Member.png" alt="axis1_COST_Foods_And_Sundries_Member.png"></div>
@@ -465,7 +465,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/COST/COST_C_A_axis2.png" alt="COST_C_A_axis2.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/COST/COST_Other_International_Member_axis2.png" alt="COST_Other_International_Member_axis2.png"></div>

--- a/pages/CRM_page.html
+++ b/pages/CRM_page.html
@@ -377,7 +377,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/CRM/axis1_CRM_Integration_And_Analytics_Member.png" alt="axis1_CRM_Integration_And_Analytics_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/CRM/axis1_CRM_Marketingand_Commerce_Cloud_Member.png" alt="axis1_CRM_Marketingand_Commerce_Cloud_Member.png"></div>
@@ -509,7 +509,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/CRM/CRM_Americas_Member_axis2.png" alt="CRM_Americas_Member_axis2.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/CRM/CRM_Asia_Pacific_Member_axis2.png" alt="CRM_Asia_Pacific_Member_axis2.png"></div>

--- a/pages/CVS_page.html
+++ b/pages/CVS_page.html
@@ -339,7 +339,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/CVS/axis1_CVS_Product_Member.png" alt="axis1_CVS_Product_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/CVS/axis1_CVS_Service_Member.png" alt="axis1_CVS_Service_Member.png"></div>

--- a/pages/CVX_page.html
+++ b/pages/CVX_page.html
@@ -350,7 +350,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/CVX/axis1_CVX_All_Other_Segments_Member.png" alt="axis1_CVX_All_Other_Segments_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/CVX/axis1_CVX_Downstream.png" alt="axis1_CVX_Downstream.png"></div>
@@ -443,7 +443,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/CVX/CVX_Non_Us_Member_axis2.png" alt="CVX_Non_Us_Member_axis2.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/CVX/CVX_U_S_axis2.png" alt="CVX_U_S_axis2.png"></div>

--- a/pages/C_page.html
+++ b/pages/C_page.html
@@ -383,7 +383,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/C/axis1_C_Banking.png" alt="axis1_C_Banking.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/C/axis1_C_Markets_Member.png" alt="axis1_C_Markets_Member.png"></div>
@@ -489,7 +489,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/C/C_Banking_axis2.png" alt="C_Banking_axis2.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/C/C_Markets_Member_axis2.png" alt="C_Markets_Member_axis2.png"></div>

--- a/pages/DAL_page.html
+++ b/pages/DAL_page.html
@@ -383,7 +383,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/DAL/axis1_DAL_Cargo_And_Freight_Member.png" alt="axis1_DAL_Cargo_And_Freight_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/DAL/axis1_DAL_Exchanged_Products_Member.png" alt="axis1_DAL_Exchanged_Products_Member.png"></div>
@@ -593,7 +593,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/DAL/axis2_DAL_Airline_Member.png" alt="axis2_DAL_Airline_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/DAL/axis2_DAL_Refinery_Member.png" alt="axis2_DAL_Refinery_Member.png"></div>

--- a/pages/DIS_page.html
+++ b/pages/DIS_page.html
@@ -350,7 +350,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/DIS/axis1_DIS_Admission_Member.png" alt="axis1_DIS_Admission_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/DIS/axis1_DIS_Advertising_Member.png" alt="axis1_DIS_Advertising_Member.png"></div>
@@ -651,7 +651,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/DIS/axis2_DIS_Content_License_Segment_Adjustment_Member.png" alt="axis2_DIS_Content_License_Segment_Adjustment_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/DIS/axis2_DIS_Eliminations_And_Other_Member.png" alt="axis2_DIS_Eliminations_And_Other_Member.png"></div>

--- a/pages/DKNG_page.html
+++ b/pages/DKNG_page.html
@@ -383,7 +383,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/DKNG/axis1_DKNG_I_Gaming_Member.png" alt="axis1_DKNG_I_Gaming_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/DKNG/axis1_DKNG_Product_And_Service_Other_Member.png" alt="axis1_DKNG_Product_And_Service_Other_Member.png"></div>
@@ -463,7 +463,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/DKNG/DKNG_Reportable_axis2.png" alt="DKNG_Reportable_axis2.png"></div>
 </div>

--- a/pages/DPZ_page.html
+++ b/pages/DPZ_page.html
@@ -372,7 +372,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/DPZ/axis1_DPZ_International_Franchise_Member.png" alt="axis1_DPZ_International_Franchise_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/DPZ/axis1_DPZ_Supply_Chain_Member.png" alt="axis1_DPZ_Supply_Chain_Member.png"></div>
@@ -444,7 +444,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/DPZ/axis2_DPZ_Domestic_Company_Owned_Stores_Member.png" alt="axis2_DPZ_Domestic_Company_Owned_Stores_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/DPZ/axis2_DPZ_Domestic_Franchise_Advertising_Member.png" alt="axis2_DPZ_Domestic_Franchise_Advertising_Member.png"></div>

--- a/pages/EVGO_page.html
+++ b/pages/EVGO_page.html
@@ -376,7 +376,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/EVGO/axis1_EVGO_Ancillary_Revenue_Member.png" alt="axis1_EVGO_Ancillary_Revenue_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/EVGO/axis1_EVGO_Charging_Network_Revenue_Member.png" alt="axis1_EVGO_Charging_Network_Revenue_Member.png"></div>

--- a/pages/FSLR_page.html
+++ b/pages/FSLR_page.html
@@ -361,7 +361,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/FSLR/axis1_FSLR_Modules.png" alt="axis1_FSLR_Modules.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/FSLR/axis1_FSLR_Other_Member.png" alt="axis1_FSLR_Other_Member.png"></div>
@@ -419,7 +419,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/FSLR/FSLR_Allotherforeigncountries_Member_axis2.png" alt="FSLR_Allotherforeigncountries_Member_axis2.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/FSLR/FSLR_C_L_axis2.png" alt="FSLR_C_L_axis2.png"></div>

--- a/pages/F_page.html
+++ b/pages/F_page.html
@@ -350,7 +350,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/F/axis1_F_All_Sales_Type_Products_And_Services_Member.png" alt="axis1_F_All_Sales_Type_Products_And_Services_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/F/axis1_F_Financingincome_Member.png" alt="axis1_F_Financingincome_Member.png"></div>
@@ -495,7 +495,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/F/axis2_F_Company_Excluding_Ford_Credit_Member.png" alt="axis2_F_Company_Excluding_Ford_Credit_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/F/axis2_F_Ford_Blue_Member.png" alt="axis2_F_Ford_Blue_Member.png"></div>

--- a/pages/GE_page.html
+++ b/pages/GE_page.html
@@ -389,7 +389,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/GE/axis1_GE_Product_Member.png" alt="axis1_GE_Product_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/GE/axis1_GE_Service_Member.png" alt="axis1_GE_Service_Member.png"></div>
@@ -456,7 +456,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/GE/axis2_GE_Commercial_Engines_And_Services_Reportable.png" alt="axis2_GE_Commercial_Engines_And_Services_Reportable.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/GE/axis2_GE_Defense_And_Propulsion_Technologies_Reportable.png" alt="axis2_GE_Defense_And_Propulsion_Technologies_Reportable.png"></div>

--- a/pages/GILD_page.html
+++ b/pages/GILD_page.html
@@ -373,7 +373,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/GILD/axis1_GILD_Cell_Therapy_Products_Tecartus_Member.png" alt="axis1_GILD_Cell_Therapy_Products_Tecartus_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/GILD/axis1_GILD_Cell_Therapy_Products_Total_Cell_Therapy_Product_Sales_Member.png" alt="axis1_GILD_Cell_Therapy_Products_Total_Cell_Therapy_Product_Sales_Member.png"></div>
@@ -700,7 +700,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/GILD/GILD_Europe_Member_axis2.png" alt="GILD_Europe_Member_axis2.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/GILD/GILD_Rest_Of_World_Member_axis2.png" alt="GILD_Rest_Of_World_Member_axis2.png"></div>

--- a/pages/GME_page.html
+++ b/pages/GME_page.html
@@ -341,7 +341,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/GME/axis1_GME_Collectibles_Member.png" alt="axis1_GME_Collectibles_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/GME/axis1_GME_Hardware_And_Accessories_Member.png" alt="axis1_GME_Hardware_And_Accessories_Member.png"></div>
@@ -434,7 +434,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/GME/axis2_GME_Australia.png" alt="axis2_GME_Australia.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/GME/axis2_GME_Canada.png" alt="axis2_GME_Canada.png"></div>

--- a/pages/GM_page.html
+++ b/pages/GM_page.html
@@ -350,7 +350,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/GM/axis1_GM_Servicesand_Other_Member.png" alt="axis1_GM_Servicesand_Other_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/GM/axis1_GM_Used_Vehicles_Member.png" alt="axis1_GM_Used_Vehicles_Member.png"></div>
@@ -430,7 +430,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/GM/axis2_GM_Cruise_Member.png" alt="axis2_GM_Cruise_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/GM/axis2_GM_G_M_I_Member.png" alt="axis2_GM_G_M_I_Member.png"></div>

--- a/pages/GOOGL_page.html
+++ b/pages/GOOGL_page.html
@@ -383,7 +383,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/GOOGL/axis1_GOOGL_Google_Advertising_Revenue_Member.png" alt="axis1_GOOGL_Google_Advertising_Revenue_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/GOOGL/axis1_GOOGL_Google_Network_Member.png" alt="axis1_GOOGL_Google_Network_Member.png"></div>
@@ -489,7 +489,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/GOOGL/axis2_GOOGL_All_Other_Segments_Member.png" alt="axis2_GOOGL_All_Other_Segments_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/GOOGL/axis2_GOOGL_Google_Cloud_Member.png" alt="axis2_GOOGL_Google_Cloud_Member.png"></div>

--- a/pages/GPI_page.html
+++ b/pages/GPI_page.html
@@ -350,7 +350,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/GPI/axis1_GPI_Financial_Service_Member.png" alt="axis1_GPI_Financial_Service_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/GPI/axis1_GPI_New_And_Used_Vehicles_Member.png" alt="axis1_GPI_New_And_Used_Vehicles_Member.png"></div>
@@ -469,7 +469,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/GPI/axis2_GPI_United_Kingdom.png" alt="axis2_GPI_United_Kingdom.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/GPI/axis2_GPI_United_States.png" alt="axis2_GPI_United_States.png"></div>

--- a/pages/GTIM_page.html
+++ b/pages/GTIM_page.html
@@ -262,7 +262,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/GTIM/axis1_GTIM_Bad_Daddys_Member.png" alt="axis1_GTIM_Bad_Daddys_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/GTIM/axis1_GTIM_Good_Times_Member.png" alt="axis1_GTIM_Good_Times_Member.png"></div>

--- a/pages/HD_page.html
+++ b/pages/HD_page.html
@@ -336,7 +336,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/HD/axis1_HD_Appliances_Member.png" alt="axis1_HD_Appliances_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/HD/axis1_HD_Bath_Member.png" alt="axis1_HD_Bath_Member.png"></div>
@@ -650,7 +650,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/HD/axis2_HD_All_Other_Segments_Member.png" alt="axis2_HD_All_Other_Segments_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/HD/axis2_HD_Primary.png" alt="axis2_HD_Primary.png"></div>

--- a/pages/HOOD_page.html
+++ b/pages/HOOD_page.html
@@ -416,7 +416,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/HOOD/axis1_HOOD_Cryptocurrencies_Member.png" alt="axis1_HOOD_Cryptocurrencies_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/HOOD/axis1_HOOD_Equities_Member.png" alt="axis1_HOOD_Equities_Member.png"></div>

--- a/pages/INTC_page.html
+++ b/pages/INTC_page.html
@@ -361,7 +361,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/INTC/axis1_INTC_All_Other_Segments_Member.png" alt="axis1_INTC_All_Other_Segments_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/INTC/axis1_INTC_Client_Computing_Group_Datacenter_And_A_I_And_Network_And_Edge_Member.png" alt="axis1_INTC_Client_Computing_Group_Datacenter_And_A_I_And_Network_And_Edge_Member.png"></div>
@@ -480,7 +480,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/INTC/INTC_All_Other_Segments_Member_axis2.png" alt="INTC_All_Other_Segments_Member_axis2.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/INTC/INTC_Client_Computing_Group_Datacenter_And_A_I_And_Network_And_Edge_Member_axis2.png" alt="INTC_Client_Computing_Group_Datacenter_And_A_I_And_Network_And_Edge_Member_axis2.png"></div>

--- a/pages/JNJ_page.html
+++ b/pages/JNJ_page.html
@@ -368,7 +368,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/JNJ/axis1_JNJ_A_D_V_A_N_C_E_D_Member.png" alt="axis1_JNJ_A_D_V_A_N_C_E_D_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/JNJ/axis1_JNJ_Abiomed_Member.png" alt="axis1_JNJ_Abiomed_Member.png"></div>
@@ -891,7 +891,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/JNJ/axis2_JNJ_Innovative_Medicine_Member.png" alt="axis2_JNJ_Innovative_Medicine_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/JNJ/axis2_JNJ_Med_Tech_Member.png" alt="axis2_JNJ_Med_Tech_Member.png"></div>

--- a/pages/KODK_page.html
+++ b/pages/KODK_page.html
@@ -251,7 +251,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/KODK/axis1_KODK_Annuities_Member.png" alt="axis1_KODK_Annuities_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/KODK/axis1_KODK_Equipment_And_Software_Member.png" alt="axis1_KODK_Equipment_And_Software_Member.png"></div>
@@ -409,7 +409,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/KODK/axis2_KODK_Advanced_Materials_And_Chemicals_Member.png" alt="axis2_KODK_Advanced_Materials_And_Chemicals_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/KODK/axis2_KODK_All_Other_Member.png" alt="axis2_KODK_All_Other_Member.png"></div>

--- a/pages/KO_page.html
+++ b/pages/KO_page.html
@@ -383,7 +383,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/KO/axis1_KO_Concentrate_Operations_Member.png" alt="axis1_KO_Concentrate_Operations_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/KO/axis1_KO_Finished_Product_Operations_Member.png" alt="axis1_KO_Finished_Product_Operations_Member.png"></div>
@@ -450,7 +450,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/KO/axis2_KO_A._Pacific_Member.png" alt="axis2_KO_A._Pacific_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/KO/axis2_KO_Bottling_Investments_Member.png" alt="axis2_KO_Bottling_Investments_Member.png"></div>

--- a/pages/LLY_page.html
+++ b/pages/LLY_page.html
@@ -383,7 +383,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/LLY/axis1_LLY_Baqsimi_Member.png" alt="axis1_LLY_Baqsimi_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/LLY/axis1_LLY_Basaglar_Member.png" alt="axis1_LLY_Basaglar_Member.png"></div>
@@ -801,7 +801,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/LLY/LLY_Reportable_axis2.png" alt="LLY_Reportable_axis2.png"></div>
 </div>

--- a/pages/LMT_page.html
+++ b/pages/LMT_page.html
@@ -357,7 +357,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/LMT/axis1_LMT_Product_Member.png" alt="axis1_LMT_Product_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/LMT/axis1_LMT_Service_Member.png" alt="axis1_LMT_Service_Member.png"></div>
@@ -424,7 +424,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/LMT/axis2_LMT_Aeronautics_Member.png" alt="axis2_LMT_Aeronautics_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/LMT/axis2_LMT_Missiles_And_Fire_Control_Member.png" alt="axis2_LMT_Missiles_And_Fire_Control_Member.png"></div>

--- a/pages/LRCX_page.html
+++ b/pages/LRCX_page.html
@@ -377,7 +377,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/LRCX/axis1_LRCX_Customer_Supportand_Other_Member.png" alt="axis1_LRCX_Customer_Supportand_Other_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/LRCX/axis1_LRCX_System_Member.png" alt="axis1_LRCX_System_Member.png"></div>
@@ -444,7 +444,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/LRCX/LRCX_Reportable_axis2.png" alt="LRCX_Reportable_axis2.png"></div>
 </div>

--- a/pages/LUV_page.html
+++ b/pages/LUV_page.html
@@ -339,7 +339,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/LUV/axis1_LUV_Cargo_And_Freight_Member.png" alt="axis1_LUV_Cargo_And_Freight_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/LUV/axis1_LUV_Other_Revenue_Member.png" alt="axis1_LUV_Other_Revenue_Member.png"></div>
@@ -471,7 +471,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/LUV/LUV_Latin_America_Member_axis2.png" alt="LUV_Latin_America_Member_axis2.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/LUV/LUV_North_America_Member_axis2.png" alt="LUV_North_America_Member_axis2.png"></div>

--- a/pages/MA_page.html
+++ b/pages/MA_page.html
@@ -366,7 +366,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/MA/axis1_MA_Payment_Network_Member.png" alt="axis1_MA_Payment_Network_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/MA/axis1_MA_Value_Added_Services_And_Solutions_Member.png" alt="axis1_MA_Value_Added_Services_And_Solutions_Member.png"></div>
@@ -433,7 +433,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/MA/MA_Payment_Solutions_Member_axis2.png" alt="MA_Payment_Solutions_Member_axis2.png"></div>
 </div>

--- a/pages/META_page.html
+++ b/pages/META_page.html
@@ -383,7 +383,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/META/axis1_META_Advertising_Member.png" alt="axis1_META_Advertising_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/META/axis1_META_Service_Other_Member.png" alt="axis1_META_Service_Other_Member.png"></div>
@@ -450,7 +450,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/META/axis2_META_Family_Of_Apps_Member.png" alt="axis2_META_Family_Of_Apps_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/META/axis2_META_Reality_Labs_Member.png" alt="axis2_META_Reality_Labs_Member.png"></div>

--- a/pages/MET_page.html
+++ b/pages/MET_page.html
@@ -357,7 +357,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/MET/axis1_MET_Administrative_Service_Member.png" alt="axis1_MET_Administrative_Service_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/MET/axis1_MET_Distribution_Service_Member.png" alt="axis1_MET_Distribution_Service_Member.png"></div>
@@ -476,7 +476,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/MET/axis2_MET_Asia.png" alt="axis2_MET_Asia.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/MET/axis2_MET_E_M_E_A.png" alt="axis2_MET_E_M_E_A.png"></div>

--- a/pages/MPC_page.html
+++ b/pages/MPC_page.html
@@ -372,7 +372,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/MPC/axis1_MPC_Crude_Oil_Member.png" alt="axis1_MPC_Crude_Oil_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/MPC/axis1_MPC_Refined_Products_Member.png" alt="axis1_MPC_Refined_Products_Member.png"></div>
@@ -452,7 +452,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/MPC/axis2_MPC_Midstream_Member.png" alt="axis2_MPC_Midstream_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/MPC/axis2_MPC_Refining_And_Marketing_Member.png" alt="axis2_MPC_Refining_And_Marketing_Member.png"></div>

--- a/pages/MRNA_page.html
+++ b/pages/MRNA_page.html
@@ -361,7 +361,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/MRNA/axis1_MRNA_C_O_V_I_D19_Member.png" alt="axis1_MRNA_C_O_V_I_D19_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/MRNA/axis1_MRNA_Collaboration_Arrangement_Including_Arrangements_With_Affiliate_Member.png" alt="axis1_MRNA_Collaboration_Arrangement_Including_Arrangements_With_Affiliate_Member.png"></div>
@@ -506,7 +506,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/MRNA/MRNA_Europe_Member_axis2.png" alt="MRNA_Europe_Member_axis2.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/MRNA/MRNA_Rest_Of_The_World_Member_axis2.png" alt="MRNA_Rest_Of_The_World_Member_axis2.png"></div>

--- a/pages/MSFT_page.html
+++ b/pages/MSFT_page.html
@@ -403,7 +403,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/MSFT/axis1_MSFT_Dynamics_Products_And_Cloud_Services_Member.png" alt="axis1_MSFT_Dynamics_Products_And_Cloud_Services_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/MSFT/axis1_MSFT_Enterprise_And_Partner_Services_Member.png" alt="axis1_MSFT_Enterprise_And_Partner_Services_Member.png"></div>
@@ -600,7 +600,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/MSFT/axis2_MSFT_Intelligent_Cloud_Member.png" alt="axis2_MSFT_Intelligent_Cloud_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/MSFT/axis2_MSFT_More_Personal_Computing_Member.png" alt="axis2_MSFT_More_Personal_Computing_Member.png"></div>

--- a/pages/MU_page.html
+++ b/pages/MU_page.html
@@ -335,7 +335,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/MU/axis1_MU_D_R_A_M_Products_Member.png" alt="axis1_MU_D_R_A_M_Products_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/MU/axis1_MU_N_A_N_D_Products_Member.png" alt="axis1_MU_N_A_N_D_Products_Member.png"></div>
@@ -415,7 +415,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/MU/axis2_MU_All_Other_Segments_Member.png" alt="axis2_MU_All_Other_Segments_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/MU/axis2_MU_C_N_B_U_Member.png" alt="axis2_MU_C_N_B_U_Member.png"></div>

--- a/pages/NET_page.html
+++ b/pages/NET_page.html
@@ -384,7 +384,7 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/NET/NET_Asia_Pacific_Member_axis2.png" alt="NET_Asia_Pacific_Member_axis2.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/NET/NET_E_M_E_A_Member_axis2.png" alt="NET_E_M_E_A_Member_axis2.png"></div>

--- a/pages/NFLX_page.html
+++ b/pages/NFLX_page.html
@@ -384,7 +384,7 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/NFLX/NFLX_Reportable_axis2.png" alt="NFLX_Reportable_axis2.png"></div>
 </div>

--- a/pages/NOC_page.html
+++ b/pages/NOC_page.html
@@ -361,7 +361,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/NOC/axis1_NOC_B21_Program_E_M_D_Phase_Member.png" alt="axis1_NOC_B21_Program_E_M_D_Phase_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/NOC/axis1_NOC_B21_Program_L_R_I_P_Options_Member.png" alt="axis1_NOC_B21_Program_L_R_I_P_Options_Member.png"></div>
@@ -480,7 +480,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/NOC/axis2_NOC_Aeronautics_Systems_Member.png" alt="axis2_NOC_Aeronautics_Systems_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/NOC/axis2_NOC_Defense_Systems_Member.png" alt="axis2_NOC_Defense_Systems_Member.png"></div>

--- a/pages/NVDA_page.html
+++ b/pages/NVDA_page.html
@@ -345,7 +345,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/NVDA/axis1_NVDA_Automotive_Member.png" alt="axis1_NVDA_Automotive_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/NVDA/axis1_NVDA_Compute_Member.png" alt="axis1_NVDA_Compute_Member.png"></div>
@@ -477,7 +477,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/NVDA/axis2_NVDA_Compute_And_Networking.png" alt="axis2_NVDA_Compute_And_Networking.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/NVDA/axis2_NVDA_Graphics.png" alt="axis2_NVDA_Graphics.png"></div>

--- a/pages/ORCL_page.html
+++ b/pages/ORCL_page.html
@@ -368,7 +368,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/ORCL/axis1_ORCL_Applications_Cloud_Services_And_License_Support_Member.png" alt="axis1_ORCL_Applications_Cloud_Services_And_License_Support_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/ORCL/axis1_ORCL_Cloud_Services_And_License_Support_Member.png" alt="axis1_ORCL_Cloud_Services_And_License_Support_Member.png"></div>
@@ -474,7 +474,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/ORCL/axis2_ORCL_Cloud_And_License_Business_Member.png" alt="axis2_ORCL_Cloud_And_License_Business_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/ORCL/axis2_ORCL_Hardware_Business_Member.png" alt="axis2_ORCL_Hardware_Business_Member.png"></div>

--- a/pages/PFE_page.html
+++ b/pages/PFE_page.html
@@ -361,7 +361,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/PFE/axis1_PFE_Paxlovid_N_D_A_Labeled_U_S_Strategic_National_Stockpile_Member.png" alt="axis1_PFE_Paxlovid_N_D_A_Labeled_U_S_Strategic_National_Stockpile_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/PFE/axis1_PFE_Product_Member.png" alt="axis1_PFE_Product_Member.png"></div>

--- a/pages/PG_page.html
+++ b/pages/PG_page.html
@@ -364,7 +364,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/PG/axis1_PG_Baby_Feminine_Family_Care.png" alt="axis1_PG_Baby_Feminine_Family_Care.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/PG/axis1_PG_Beauty.png" alt="axis1_PG_Beauty.png"></div>
@@ -470,7 +470,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/PG/PG_Non_Us_Member_axis2.png" alt="PG_Non_Us_Member_axis2.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/PG/PG_U_S_axis2.png" alt="PG_U_S_axis2.png"></div>

--- a/pages/PLTR_page.html
+++ b/pages/PLTR_page.html
@@ -398,7 +398,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/PLTR/axis1_PLTR_Commercial.png" alt="axis1_PLTR_Commercial.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/PLTR/axis1_PLTR_Commercial_Operating.png" alt="axis1_PLTR_Commercial_Operating.png"></div>
@@ -478,7 +478,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/PLTR/PLTR_G_B_axis2.png" alt="PLTR_G_B_axis2.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/PLTR/PLTR_Rest_Of_World_Member_axis2.png" alt="PLTR_Rest_Of_World_Member_axis2.png"></div>

--- a/pages/PYPL_page.html
+++ b/pages/PYPL_page.html
@@ -383,7 +383,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/PYPL/axis1_PYPL_Revenues_From_Other_Value_Added_Services_Member.png" alt="axis1_PYPL_Revenues_From_Other_Value_Added_Services_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/PYPL/axis1_PYPL_Transaction_Revenue_Member.png" alt="axis1_PYPL_Transaction_Revenue_Member.png"></div>
@@ -463,7 +463,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/PYPL/PYPL_Reportable_axis2.png" alt="PYPL_Reportable_axis2.png"></div>
 </div>

--- a/pages/RCL_page.html
+++ b/pages/RCL_page.html
@@ -350,7 +350,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/RCL/axis1_RCL_Cruise_Itinerary_Member.png" alt="axis1_RCL_Cruise_Itinerary_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/RCL/axis1_RCL_Other_Products_And_Services_Member.png" alt="axis1_RCL_Other_Products_And_Services_Member.png"></div>
@@ -456,7 +456,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/RCL/RCL_Asia_Pacific_Member_axis2.png" alt="RCL_Asia_Pacific_Member_axis2.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/RCL/RCL_Europe_Member_axis2.png" alt="RCL_Europe_Member_axis2.png"></div>

--- a/pages/RDDT_page.html
+++ b/pages/RDDT_page.html
@@ -383,7 +383,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/RDDT/axis1_RDDT_Advertising_Member.png" alt="axis1_RDDT_Advertising_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/RDDT/axis1_RDDT_Other_Revenue_Member.png" alt="axis1_RDDT_Other_Revenue_Member.png"></div>
@@ -450,7 +450,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/RDDT/RDDT_Reportable_axis2.png" alt="RDDT_Reportable_axis2.png"></div>
 </div>

--- a/pages/RIVN_page.html
+++ b/pages/RIVN_page.html
@@ -373,7 +373,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/RIVN/axis1_RIVN_Automotive_Member.png" alt="axis1_RIVN_Automotive_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/RIVN/axis1_RIVN_Regulatory_Credits_Member.png" alt="axis1_RIVN_Regulatory_Credits_Member.png"></div>
@@ -505,7 +505,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/RIVN/axis2_RIVN_Automotive.png" alt="axis2_RIVN_Automotive.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/RIVN/axis2_RIVN_Software_And_Services.png" alt="axis2_RIVN_Software_And_Services.png"></div>

--- a/pages/RTX_page.html
+++ b/pages/RTX_page.html
@@ -383,7 +383,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/RTX/axis1_RTX_Product_Member.png" alt="axis1_RTX_Product_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/RTX/axis1_RTX_Service_Member.png" alt="axis1_RTX_Service_Member.png"></div>
@@ -450,7 +450,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/RTX/axis2_RTX_Acquisition_Accounting_Adjustments_Member.png" alt="axis2_RTX_Acquisition_Accounting_Adjustments_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/RTX/axis2_RTX_F_A_S_C_A_S_Operating_Adjustment_Member.png" alt="axis2_RTX_F_A_S_C_A_S_Operating_Adjustment_Member.png"></div>

--- a/pages/SBUX_page.html
+++ b/pages/SBUX_page.html
@@ -361,7 +361,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/SBUX/axis1_SBUX_Beverage_Member.png" alt="axis1_SBUX_Beverage_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/SBUX/axis1_SBUX_Company_Operated_Stores_Member.png" alt="axis1_SBUX_Company_Operated_Stores_Member.png"></div>
@@ -480,7 +480,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/SBUX/axis2_SBUX_Channel_Development_Member.png" alt="axis2_SBUX_Channel_Development_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/SBUX/axis2_SBUX_Corporate_And_Other_Member.png" alt="axis2_SBUX_Corporate_And_Other_Member.png"></div>

--- a/pages/SCHW_page.html
+++ b/pages/SCHW_page.html
@@ -372,7 +372,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/SCHW/axis1_SCHW_Asset_Management_And_Administration_Service_Member.png" alt="axis1_SCHW_Asset_Management_And_Administration_Service_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/SCHW/axis1_SCHW_Bank_Deposit_Account_Fees_Member.png" alt="axis1_SCHW_Bank_Deposit_Account_Fees_Member.png"></div>
@@ -543,7 +543,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/SCHW/SCHW_Advisor_Services_Member_axis2.png" alt="SCHW_Advisor_Services_Member_axis2.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/SCHW/SCHW_Investor_Services_Member_axis2.png" alt="SCHW_Investor_Services_Member_axis2.png"></div>

--- a/pages/SHOP_page.html
+++ b/pages/SHOP_page.html
@@ -383,7 +383,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/SHOP/axis1_SHOP_Service_Member.png" alt="axis1_SHOP_Service_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/SHOP/axis1_SHOP_Subscription_And_Circulation_Member.png" alt="axis1_SHOP_Subscription_And_Circulation_Member.png"></div>
@@ -450,7 +450,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/SHOP/SHOP_A_P_A_C_Member_axis2.png" alt="SHOP_A_P_A_C_Member_axis2.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/SHOP/SHOP_C_A_axis2.png" alt="SHOP_C_A_axis2.png"></div>

--- a/pages/SNAP_page.html
+++ b/pages/SNAP_page.html
@@ -383,7 +383,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/SNAP/axis1_SNAP_Advertising_Revenue_Member.png" alt="axis1_SNAP_Advertising_Revenue_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/SNAP/axis1_SNAP_Other_Revenue_Member.png" alt="axis1_SNAP_Other_Revenue_Member.png"></div>
@@ -432,7 +432,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/SNAP/SNAP_Reportable_axis2.png" alt="SNAP_Reportable_axis2.png"></div>
 </div>

--- a/pages/TEVA_page.html
+++ b/pages/TEVA_page.html
@@ -383,7 +383,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/TEVA/axis1_TEVA_Ajovy_Member.png" alt="axis1_TEVA_Ajovy_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/TEVA/axis1_TEVA_Anda_Member.png" alt="axis1_TEVA_Anda_Member.png"></div>
@@ -593,7 +593,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/TEVA/axis2_TEVA_All_Other_Segments_Member.png" alt="axis2_TEVA_All_Other_Segments_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/TEVA/axis2_TEVA_Corporate_Member.png" alt="axis2_TEVA_Corporate_Member.png"></div>

--- a/pages/TGT_page.html
+++ b/pages/TGT_page.html
@@ -341,7 +341,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/TGT/axis1_TGT_Advertising_Revenue_Member.png" alt="axis1_TGT_Advertising_Revenue_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/TGT/axis1_TGT_Apparel_And_Accessories_Member.png" alt="axis1_TGT_Apparel_And_Accessories_Member.png"></div>
@@ -525,7 +525,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/TGT/TGT_Reportable_axis2.png" alt="TGT_Reportable_axis2.png"></div>
 </div>

--- a/pages/TSLA_page.html
+++ b/pages/TSLA_page.html
@@ -361,7 +361,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/TSLA/axis1_TSLA_Automotive_Leasing_Member.png" alt="axis1_TSLA_Automotive_Leasing_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/TSLA/axis1_TSLA_Automotive_Regulatory_Credits_Member.png" alt="axis1_TSLA_Automotive_Regulatory_Credits_Member.png"></div>

--- a/pages/TSN_page.html
+++ b/pages/TSN_page.html
@@ -350,7 +350,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/TSN/axis1_TSN_Beef_Member.png" alt="axis1_TSN_Beef_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/TSN/axis1_TSN_Chicken_Member.png" alt="axis1_TSN_Chicken_Member.png"></div>

--- a/pages/UAL_page.html
+++ b/pages/UAL_page.html
@@ -361,7 +361,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/UAL/axis1_UAL_Ancillary_Services_Member.png" alt="axis1_UAL_Ancillary_Services_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/UAL/axis1_UAL_Cargo_And_Freight_Member.png" alt="axis1_UAL_Cargo_And_Freight_Member.png"></div>

--- a/pages/UBER_page.html
+++ b/pages/UBER_page.html
@@ -383,7 +383,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/UBER/axis1_UBER_Delivery_Member.png" alt="axis1_UBER_Delivery_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/UBER/axis1_UBER_Freight_Member.png" alt="axis1_UBER_Freight_Member.png"></div>
@@ -463,7 +463,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/UBER/UBER_All_Other_Countries_Member_axis2.png" alt="UBER_All_Other_Countries_Member_axis2.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/UBER/UBER_Asia_Pacific_Member_axis2.png" alt="UBER_Asia_Pacific_Member_axis2.png"></div>

--- a/pages/UNH_page.html
+++ b/pages/UNH_page.html
@@ -324,7 +324,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/UNH/axis1_UNH_Product_Member.png" alt="axis1_UNH_Product_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/UNH/axis1_UNH_Service_Member.png" alt="axis1_UNH_Service_Member.png"></div>
@@ -391,7 +391,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/UNH/axis2_UNH_Optum_Health_Member.png" alt="axis2_UNH_Optum_Health_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/UNH/axis2_UNH_Optum_Insight_Member.png" alt="axis2_UNH_Optum_Insight_Member.png"></div>

--- a/pages/UPS_page.html
+++ b/pages/UPS_page.html
@@ -339,7 +339,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/UPS/axis1_UPS_Cargo_And_Other_Member.png" alt="axis1_UPS_Cargo_And_Other_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/UPS/axis1_UPS_Cargo_Member.png" alt="axis1_UPS_Cargo_Member.png"></div>
@@ -510,7 +510,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/UPS/axis2_UPS_International.png" alt="axis2_UPS_International.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/UPS/axis2_UPS_International_Package_Member.png" alt="axis2_UPS_International_Package_Member.png"></div>

--- a/pages/VLO_page.html
+++ b/pages/VLO_page.html
@@ -383,7 +383,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/VLO/axis1_VLO_Ethanol_Member.png" alt="axis1_VLO_Ethanol_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/VLO/axis1_VLO_Refining_Member.png" alt="axis1_VLO_Refining_Member.png"></div>

--- a/pages/VZ_page.html
+++ b/pages/VZ_page.html
@@ -350,7 +350,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/VZ/axis1_VZ_Business_Markets_And_Other_Member.png" alt="axis1_VZ_Business_Markets_And_Other_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/VZ/axis1_VZ_Enterprise_And_Public_Sector_Member.png" alt="axis1_VZ_Enterprise_And_Public_Sector_Member.png"></div>
@@ -508,7 +508,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/VZ/axis2_VZ_Verizon_Business_Group.png" alt="axis2_VZ_Verizon_Business_Group.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/VZ/axis2_VZ_Verizon_Consumer_Group.png" alt="axis2_VZ_Verizon_Consumer_Group.png"></div>

--- a/pages/V_page.html
+++ b/pages/V_page.html
@@ -366,7 +366,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/V/axis1_V_Client_Incentives_Member.png" alt="axis1_V_Client_Incentives_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/V/axis1_V_Data_Processing_Revenues_Member.png" alt="axis1_V_Data_Processing_Revenues_Member.png"></div>
@@ -485,7 +485,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/V/V_Non_Us_Member_axis2.png" alt="V_Non_Us_Member_axis2.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/V/V_U_S_axis2.png" alt="V_U_S_axis2.png"></div>

--- a/pages/WMT_page.html
+++ b/pages/WMT_page.html
@@ -336,7 +336,7 @@
 
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/WMT/axis1_WMT_Fuel_And_Other_Member.png" alt="axis1_WMT_Fuel_And_Other_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/WMT/axis1_WMT_General_Merchandise_Member.png" alt="axis1_WMT_General_Merchandise_Member.png"></div>
@@ -442,7 +442,6 @@
   
   
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     <div class="carousel-container chart-block">
 <div class="carousel-item"><img class="chart-img" src="../charts/WMT/axis2_WMT_Sams_Club_U_S_Member.png" alt="axis2_WMT_Sams_Club_U_S_Member.png"></div>
 <div class="carousel-item"><img class="chart-img" src="../charts/WMT/axis2_WMT_Walmart_International_Member.png" alt="axis2_WMT_Walmart_International_Member.png"></div>

--- a/templates/ticker_template.html
+++ b/templates/ticker_template.html
@@ -43,7 +43,7 @@
 
   {% if ticker_data.segment_carousel_html_axis1 %}
   <div class="chart-block">
-    <h2>Segment Performance (Axis 1)</h2>
+    <h2>Segment Performance</h2>
     {{ ticker_data.segment_carousel_html_axis1 | safe }}
     <div class="segment-table-wrapper">
       <div class="table-wrap">
@@ -54,7 +54,6 @@
   {% endif %}
   {% if ticker_data.segment_carousel_html_axis2 %}
   <div class="chart-block">
-    <h2>Segment Performance (Axis 2)</h2>
     {{ ticker_data.segment_carousel_html_axis2 | safe }}
     <div class="segment-table-wrapper">
       <div class="table-wrap">


### PR DESCRIPTION
## Summary
- Avoid repeating "Segment Performance" heading for axis 2 content in template and generator
- Update ticker pages so only a single segment heading remains per page

## Testing
- `python -m py_compile html_generator2.py`
- `Email=test@example.com pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba2289156c83319b440f7c25a78d5a