### PR TITLE
Refactor annual/TTM updates to reuse DB connection

### DIFF
--- a/annual_and_ttm_update.py
+++ b/annual_and_ttm_update.py
@@ -150,9 +150,8 @@ def _store_ttm(tkr: str, d: dict, cur: sqlite3.Cursor):
     ))
 
 # ───────────────────────── main entry ─────────────────────────
-def annual_and_ttm_update(tkr: str, db_path: str = DB_PATH):
-    conn = get_db_connection(db_path)
-    cur  = conn.cursor()
+def annual_and_ttm_update(tkr: str, cur: sqlite3.Cursor):
+    """Update annual and TTM data for ``tkr`` using an existing cursor."""
 
     # Annual (only if none exist)
     cur.execute("SELECT 1 FROM Annual_Data WHERE Symbol=? LIMIT 1", (tkr,))
@@ -166,11 +165,14 @@ def annual_and_ttm_update(tkr: str, db_path: str = DB_PATH):
     if ttm:
         _store_ttm(tkr, ttm, cur)
 
-    conn.commit()
-    conn.close()
+    # Commit changes but leave connection management to caller
+    cur.connection.commit()
     logging.info("[%s] annual+TTM update complete", tkr)
 
 # stand-alone sanity test
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(message)s")
-    annual_and_ttm_update("AAPL")
+    conn = get_db_connection(DB_PATH)
+    cur = conn.cursor()
+    annual_and_ttm_update("AAPL", cur)
+    conn.close()

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ import os
 import sqlite3
 import ticker_manager
 from datetime import datetime
-from annual_and_ttm_update import annual_and_ttm_update
+from annual_and_ttm_update import annual_and_ttm_update, get_db_connection
 from html_generator import (create_html_for_tickers)
 from balance_sheet_data_fetcher import (
     fetch_balance_sheet_data,
@@ -67,13 +67,8 @@ def manage_tickers(TICKERS_FILE_PATH, is_remote=False):
 def establish_database_connection(db_path):
     print("main 2 establish database connection")
     db_full_path = os.path.abspath(db_path)
-
-    if not os.path.exists(db_full_path):
-        print(f"Database file not found: {db_full_path}")
-        return None
-
-    print("Database exists. Establishing connection...")
-    return sqlite3.connect(db_full_path)
+    print("Establishing connection and ensuring schema...")
+    return get_db_connection(db_full_path)
 
 
 # Add the log_average_valuations function
@@ -237,7 +232,7 @@ def main():
             print(f"Processing ticker: {ticker}")
 
             # Existing data fetching and processing
-            annual_and_ttm_update(ticker,db_path)
+            annual_and_ttm_update(ticker, cursor)
 
             # Fetch and update balance sheet data
             fetch_and_update_balance_sheet_data(ticker, cursor)

--- a/main_remote.py
+++ b/main_remote.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import ticker_manager
 from generate_economic_data    import generate_economic_data
-from annual_and_ttm_update     import annual_and_ttm_update
+from annual_and_ttm_update     import annual_and_ttm_update, get_db_connection
 from html_generator            import create_html_for_tickers
 from balance_sheet_data_fetcher import (
     fetch_balance_sheet_data, check_missing_balance_sheet_data,
@@ -56,10 +56,8 @@ def manage_tickers(tickers_file, is_remote=False):
     return tickers
 
 def establish_database_connection(db_path):
-    if not os.path.exists(db_path):
-        print(f"[ERROR] Database not found at {db_path}")
-        return None
-    return sqlite3.connect(db_path)
+    # Ensure schema once and return a ready connection
+    return get_db_connection(db_path)
 
 def log_average_valuations(avg_values, tickers_file):
     if tickers_file != "tickers.csv":
@@ -173,7 +171,7 @@ def mini_main():
                 if not ok:
                     missing_segments.append(ticker)
 
-                annual_and_ttm_update(ticker, DB_PATH)
+                annual_and_ttm_update(ticker, cursor)
                 fetch_and_update_balance_sheet_data(ticker, cursor)
                 balancesheet_chart(ticker)
                 scrape_forward_data(ticker)


### PR DESCRIPTION
## Summary
- Update `annual_and_ttm_update` to use an existing database cursor and commit without managing connections
- Open SQLite connection once in `main` scripts and pass cursor to update function
- Run schema checks a single time before processing tickers

## Testing
- `python -m py_compile annual_and_ttm_update.py main.py main_remote.py`
- `pytest -q` *(fails: `SystemExit: ERROR: export Email='your.sec.address@example.com' first`)*

------
https://chatgpt.com/codex/tasks/task_e_68bae6a0234483319f81affb921b177f