### PR TITLE
Add raw segment data links

### DIFF
--- a/pages/AAL_page.html
+++ b/pages/AAL_page.html
@@ -493,6 +493,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/AAL/AAL_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/AAL_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/AAPL_page.html
+++ b/pages/AAPL_page.html
@@ -584,6 +584,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/AAPL/AAPL_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/AAPL_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/ABBV_page.html
+++ b/pages/ABBV_page.html
@@ -842,6 +842,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/ABBV/ABBV_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/ABBV_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/ADBE_page.html
+++ b/pages/ADBE_page.html
@@ -511,6 +511,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/ADBE/ADBE_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/ADBE_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/AMAT_page.html
+++ b/pages/AMAT_page.html
@@ -459,6 +459,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/AMAT/AMAT_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/AMAT_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/AMD_page.html
+++ b/pages/AMD_page.html
@@ -514,6 +514,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/AMD/AMD_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/AMD_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/AMZN_page.html
+++ b/pages/AMZN_page.html
@@ -608,6 +608,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/AMZN/AMZN_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/AMZN_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/AVGO_page.html
+++ b/pages/AVGO_page.html
@@ -475,6 +475,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/AVGO/AVGO_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/AVGO_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/AXP_page.html
+++ b/pages/AXP_page.html
@@ -465,6 +465,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/AXP/AXP_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/AXP_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/BABA_page.html
+++ b/pages/BABA_page.html
@@ -399,6 +399,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/BABA/BABA_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/BABA_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/BAC_page.html
+++ b/pages/BAC_page.html
@@ -373,6 +373,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/BAC/BAC_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/BAC_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/BAH_page.html
+++ b/pages/BAH_page.html
@@ -362,6 +362,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/BAH/BAH_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/BAH_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/BA_page.html
+++ b/pages/BA_page.html
@@ -468,6 +468,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/BA/BA_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/BA_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/BIRD_page.html
+++ b/pages/BIRD_page.html
@@ -373,6 +373,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/BIRD/BIRD_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/BIRD_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/BRK-B_page.html
+++ b/pages/BRK-B_page.html
@@ -662,6 +662,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/BRK-B/BRK-B_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/BRK-B_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/BUD_page.html
+++ b/pages/BUD_page.html
@@ -373,6 +373,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/BUD/BUD_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/BUD_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/BYND_page.html
+++ b/pages/BYND_page.html
@@ -389,6 +389,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/BYND/BYND_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/BYND_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/CCL_page.html
+++ b/pages/CCL_page.html
@@ -497,6 +497,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/CCL/CCL_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/CCL_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/CELH_page.html
+++ b/pages/CELH_page.html
@@ -387,6 +387,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/CELH/CELH_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/CELH_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/CMG_page.html
+++ b/pages/CMG_page.html
@@ -436,6 +436,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/CMG/CMG_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/CMG_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/COIN_page.html
+++ b/pages/COIN_page.html
@@ -552,6 +552,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/COIN/COIN_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/COIN_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/COST_page.html
+++ b/pages/COST_page.html
@@ -479,6 +479,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/COST/COST_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/COST_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/CRM_page.html
+++ b/pages/CRM_page.html
@@ -522,6 +522,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/CRM/CRM_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/CRM_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/CVS_page.html
+++ b/pages/CVS_page.html
@@ -406,6 +406,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/CVS/CVS_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/CVS_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/CVX_page.html
+++ b/pages/CVX_page.html
@@ -455,6 +455,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/CVX/CVX_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/CVX_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/C_page.html
+++ b/pages/C_page.html
@@ -504,6 +504,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/C/C_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/C_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/DAL_page.html
+++ b/pages/DAL_page.html
@@ -658,6 +658,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/DAL/DAL_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/DAL_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/DIS_page.html
+++ b/pages/DIS_page.html
@@ -755,6 +755,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/DIS/DIS_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/DIS_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/DJT_page.html
+++ b/pages/DJT_page.html
@@ -235,6 +235,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/DJT/DJT_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/DJT_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/DKNG_page.html
+++ b/pages/DKNG_page.html
@@ -474,6 +474,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/DKNG/DKNG_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/DKNG_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/DPZ_page.html
+++ b/pages/DPZ_page.html
@@ -547,6 +547,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/DPZ/DPZ_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/DPZ_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/EVGO_page.html
+++ b/pages/EVGO_page.html
@@ -503,6 +503,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/EVGO/EVGO_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/EVGO_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/FSLR_page.html
+++ b/pages/FSLR_page.html
@@ -434,6 +434,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/FSLR/FSLR_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/FSLR_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/F_page.html
+++ b/pages/F_page.html
@@ -612,6 +612,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/F/F_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/F_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/GE_page.html
+++ b/pages/GE_page.html
@@ -518,6 +518,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/GE/GE_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/GE_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/GILD_page.html
+++ b/pages/GILD_page.html
@@ -713,6 +713,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/GILD/GILD_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/GILD_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/GME_page.html
+++ b/pages/GME_page.html
@@ -520,6 +520,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/GME/GME_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/GME_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/GM_page.html
+++ b/pages/GM_page.html
@@ -521,6 +521,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/GM/GM_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/GM_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/GOOGL_page.html
+++ b/pages/GOOGL_page.html
@@ -567,6 +567,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/GOOGL/GOOGL_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/GOOGL_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/GPI_page.html
+++ b/pages/GPI_page.html
@@ -534,6 +534,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/GPI/GPI_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/GPI_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/GS_page.html
+++ b/pages/GS_page.html
@@ -373,6 +373,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/GS/GS_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/GS_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/GTIM_page.html
+++ b/pages/GTIM_page.html
@@ -320,6 +320,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/GTIM/GTIM_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/GTIM_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/HD_page.html
+++ b/pages/HD_page.html
@@ -728,6 +728,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/HD/HD_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/HD_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/HOOD_page.html
+++ b/pages/HOOD_page.html
@@ -587,6 +587,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/HOOD/HOOD_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/HOOD_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/INTC_page.html
+++ b/pages/INTC_page.html
@@ -496,6 +496,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/INTC/INTC_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/INTC_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/JNJ_page.html
+++ b/pages/JNJ_page.html
@@ -950,6 +950,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/JNJ/JNJ_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/JNJ_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/JPM_page.html
+++ b/pages/JPM_page.html
@@ -379,6 +379,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/JPM/JPM_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/JPM_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/KHC_page.html
+++ b/pages/KHC_page.html
@@ -384,6 +384,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/KHC/KHC_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/KHC_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/KODK_page.html
+++ b/pages/KODK_page.html
@@ -526,6 +526,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/KODK/KODK_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/KODK_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/KO_page.html
+++ b/pages/KO_page.html
@@ -606,6 +606,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/KO/KO_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/KO_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/LLY_page.html
+++ b/pages/LLY_page.html
@@ -812,6 +812,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/LLY/LLY_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/LLY_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/LMT_page.html
+++ b/pages/LMT_page.html
@@ -515,6 +515,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/LMT/LMT_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/LMT_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/LRCX_page.html
+++ b/pages/LRCX_page.html
@@ -455,6 +455,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/LRCX/LRCX_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/LRCX_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/LULU_page.html
+++ b/pages/LULU_page.html
@@ -447,6 +447,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/LULU/LULU_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/LULU_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/LUV_page.html
+++ b/pages/LUV_page.html
@@ -483,6 +483,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/LUV/LUV_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/LUV_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/MAMA_page.html
+++ b/pages/MAMA_page.html
@@ -370,6 +370,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/MAMA/MAMA_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/MAMA_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/MA_page.html
+++ b/pages/MA_page.html
@@ -444,6 +444,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/MA/MA_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/MA_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/META_page.html
+++ b/pages/META_page.html
@@ -515,6 +515,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/META/META_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/META_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/MET_page.html
+++ b/pages/MET_page.html
@@ -586,6 +586,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/MET/MET_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/MET_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/MPC_page.html
+++ b/pages/MPC_page.html
@@ -530,6 +530,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/MPC/MPC_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/MPC_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/MRNA_page.html
+++ b/pages/MRNA_page.html
@@ -520,6 +520,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/MRNA/MRNA_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/MRNA_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/MSFT_page.html
+++ b/pages/MSFT_page.html
@@ -678,6 +678,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/MSFT/MSFT_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/MSFT_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/MU_page.html
+++ b/pages/MU_page.html
@@ -519,6 +519,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/MU/MU_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/MU_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/NCLH_page.html
+++ b/pages/NCLH_page.html
@@ -351,6 +351,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/NCLH/NCLH_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/NCLH_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/NET_page.html
+++ b/pages/NET_page.html
@@ -398,6 +398,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/NET/NET_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/NET_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/NFLX_page.html
+++ b/pages/NFLX_page.html
@@ -395,6 +395,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/NFLX/NFLX_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/NFLX_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/NOC_page.html
+++ b/pages/NOC_page.html
@@ -571,6 +571,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/NOC/NOC_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/NOC_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/NVDA_page.html
+++ b/pages/NVDA_page.html
@@ -542,6 +542,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/NVDA/NVDA_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/NVDA_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/OPEN_page.html
+++ b/pages/OPEN_page.html
@@ -285,6 +285,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/OPEN/OPEN_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/OPEN_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/ORCL_page.html
+++ b/pages/ORCL_page.html
@@ -552,6 +552,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/ORCL/ORCL_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/ORCL_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/PENN_page.html
+++ b/pages/PENN_page.html
@@ -362,6 +362,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/PENN/PENN_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/PENN_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/PERI_page.html
+++ b/pages/PERI_page.html
@@ -395,6 +395,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/PERI/PERI_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/PERI_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/PFE_page.html
+++ b/pages/PFE_page.html
@@ -441,6 +441,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/PFE/PFE_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/PFE_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/PG_page.html
+++ b/pages/PG_page.html
@@ -482,6 +482,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/PG/PG_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/PG_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/PINS_page.html
+++ b/pages/PINS_page.html
@@ -384,6 +384,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/PINS/PINS_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/PINS_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/PLTR_page.html
+++ b/pages/PLTR_page.html
@@ -491,6 +491,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/PLTR/PLTR_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/PLTR_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/PYPL_page.html
+++ b/pages/PYPL_page.html
@@ -474,6 +474,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/PYPL/PYPL_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/PYPL_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/RCL_page.html
+++ b/pages/RCL_page.html
@@ -470,6 +470,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/RCL/RCL_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/RCL_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/RDDT_page.html
+++ b/pages/RDDT_page.html
@@ -461,6 +461,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/RDDT/RDDT_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/RDDT_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/RIVN_page.html
+++ b/pages/RIVN_page.html
@@ -517,6 +517,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/RIVN/RIVN_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/RIVN_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/RTX_page.html
+++ b/pages/RTX_page.html
@@ -494,6 +494,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/RTX/RTX_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/RTX_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/SBUX_page.html
+++ b/pages/SBUX_page.html
@@ -571,6 +571,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/SBUX/SBUX_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/SBUX_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/SCHW_page.html
+++ b/pages/SCHW_page.html
@@ -555,6 +555,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/SCHW/SCHW_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/SCHW_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/SHOP_page.html
+++ b/pages/SHOP_page.html
@@ -465,6 +465,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/SHOP/SHOP_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/SHOP_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/SNAP_page.html
+++ b/pages/SNAP_page.html
@@ -443,6 +443,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/SNAP/SNAP_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/SNAP_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/SPOT_page.html
+++ b/pages/SPOT_page.html
@@ -384,6 +384,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/SPOT/SPOT_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/SPOT_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/TEVA_page.html
+++ b/pages/TEVA_page.html
@@ -710,6 +710,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/TEVA/TEVA_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/TEVA_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/TGT_page.html
+++ b/pages/TGT_page.html
@@ -536,6 +536,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/TGT/TGT_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/TGT_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/TSLA_page.html
+++ b/pages/TSLA_page.html
@@ -519,6 +519,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/TSLA/TSLA_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/TSLA_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/TSN_page.html
+++ b/pages/TSN_page.html
@@ -469,6 +469,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/TSN/TSN_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/TSN_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/UAL_page.html
+++ b/pages/UAL_page.html
@@ -467,6 +467,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/UAL/UAL_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/UAL_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/UBER_page.html
+++ b/pages/UBER_page.html
@@ -480,6 +480,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/UBER/UBER_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/UBER_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/UNH_page.html
+++ b/pages/UNH_page.html
@@ -525,6 +525,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/UNH/UNH_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/UNH_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/UPS_page.html
+++ b/pages/UPS_page.html
@@ -614,6 +614,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/UPS/UPS_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/UPS_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/VLO_page.html
+++ b/pages/VLO_page.html
@@ -459,6 +459,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/VLO/VLO_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/VLO_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/VRSN_page.html
+++ b/pages/VRSN_page.html
@@ -384,6 +384,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/VRSN/VRSN_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/VRSN_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/VZ_page.html
+++ b/pages/VZ_page.html
@@ -573,6 +573,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/VZ/VZ_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/VZ_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/V_page.html
+++ b/pages/V_page.html
@@ -497,6 +497,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/V/V_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/V_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/WMT_page.html
+++ b/pages/WMT_page.html
@@ -520,6 +520,8 @@
   </div>
   
 
+  <p class="chart-block"><a href="../charts/WMT/WMT_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/WMT_balance_sheet_chart.png" alt="Balance Sheet">

--- a/pages/XOM_page.html
+++ b/pages/XOM_page.html
@@ -373,6 +373,8 @@
   
   
 
+  <p class="chart-block"><a href="../charts/XOM/XOM_segment_raw.txt">Raw segment data (TXT)</a></p>
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="../charts/XOM_balance_sheet_chart.png" alt="Balance Sheet">

--- a/templates/ticker_template.html
+++ b/templates/ticker_template.html
@@ -63,6 +63,10 @@
   </div>
   {% endif %}
 
+  {% if ticker_data.segment_raw_txt_path %}
+  <p class="chart-block"><a href="{{ ticker_data.segment_raw_txt_path }}">Raw segment data (TXT)</a></p>
+  {% endif %}
+
   <div class="chart-block">
     <h2>Balance Sheet</h2>
     <img class="chart-img chart-block" src="{{ ticker_data.balance_sheet_chart_path }}" alt="Balance Sheet">


### PR DESCRIPTION
## Summary
- Add link to raw business segment TXT in ticker template
- Populate raw segment links across ticker pages

## Testing
- `python -m py_compile StockFinances/html_generator2.py`


------
https://chatgpt.com/codex/tasks/task_e_68bae88be48083318c5c556062978605