### PR TITLE
Generate QQQ index growth page with SPY styling

### DIFF
--- a/charts/qqq_growth_summary.html
+++ b/charts/qqq_growth_summary.html
@@ -1,36 +1,35 @@
-<table border="1" class="dataframe">
+
+<style>
+.summary-table{width:100%;border-collapse:collapse;
+  font-family:Verdana,Arial,sans-serif;font-size:12px;
+  border:3px solid #003366;}
+.summary-table th{background:#f2f2f2;padding:4px 6px;
+  border:1px solid #B0B0B0;text-align:center;}
+.summary-table td{padding:4px 6px;border:1px solid #B0B0B0;text-align:center;}
+</style>
+<style type="text/css">
+</style>
+<table id="T_26845" class="summary-table">
   <thead>
-    <tr style="text-align: right;">
-      <th>Ticker</th>
-      <th>Type</th>
-      <th>Stat</th>
-      <th>Value</th>
+    <tr>
+      <th id="T_26845_level0_col0" class="col_heading level0 col0" >Metric</th>
+      <th id="T_26845_level0_col1" class="col_heading level0 col1" >Latest</th>
+      <th id="T_26845_level0_col2" class="col_heading level0 col2" >Avg</th>
+      <th id="T_26845_level0_col3" class="col_heading level0 col3" >Med</th>
+      <th id="T_26845_level0_col4" class="col_heading level0 col4" >Min</th>
+      <th id="T_26845_level0_col5" class="col_heading level0 col5" >Max</th>
+      <th id="T_26845_level0_col6" class="col_heading level0 col6" >%ctile</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td><a href="qqq_growth.html">QQQ</a></td>
-      <td>TTM</td>
-      <td>Avg</td>
-      <td>43.71%</td>
-    </tr>
-    <tr>
-      <td><a href="qqq_growth.html">QQQ</a></td>
-      <td>TTM</td>
-      <td>Med</td>
-      <td>43.21%</td>
-    </tr>
-    <tr>
-      <td><a href="qqq_growth.html">QQQ</a></td>
-      <td>TTM</td>
-      <td>Min</td>
-      <td>37.91%</td>
-    </tr>
-    <tr>
-      <td><a href="qqq_growth.html">QQQ</a></td>
-      <td>TTM</td>
-      <td>Max</td>
-      <td>50.51%</td>
+      <td id="T_26845_row0_col0" class="data row0 col0" >Implied Growth (TTM)</td>
+      <td id="T_26845_row0_col1" class="data row0 col1" >42.12 %</td>
+      <td id="T_26845_row0_col2" class="data row0 col2" >43.80 %</td>
+      <td id="T_26845_row0_col3" class="data row0 col3" >43.21 %</td>
+      <td id="T_26845_row0_col4" class="data row0 col4" >40.17 %</td>
+      <td id="T_26845_row0_col5" class="data row0 col5" >50.51 %</td>
+      <td id="T_26845_row0_col6" class="data row0 col6" >35</td>
     </tr>
   </tbody>
 </table>

--- a/charts/qqq_pe_summary.html
+++ b/charts/qqq_pe_summary.html
@@ -1,36 +1,39 @@
-<table border="1" class="dataframe">
+
+<style>
+.summary-table{width:100%;border-collapse:collapse;
+  font-family:Verdana,Arial,sans-serif;font-size:12px;
+  border:3px solid #003366;}
+.summary-table th{background:#f2f2f2;padding:4px 6px;
+  border:1px solid #B0B0B0;text-align:center;}
+.summary-table td{padding:4px 6px;border:1px solid #B0B0B0;text-align:center;}
+</style>
+<style type="text/css">
+#T_fda38_row0_col6 {
+  color: #CC0000;
+  font-weight: bold;
+}
+</style>
+<table id="T_fda38" class="summary-table">
   <thead>
-    <tr style="text-align: right;">
-      <th>Ticker</th>
-      <th>Type</th>
-      <th>Stat</th>
-      <th>Value</th>
+    <tr>
+      <th id="T_fda38_level0_col0" class="col_heading level0 col0" >Metric</th>
+      <th id="T_fda38_level0_col1" class="col_heading level0 col1" >Latest</th>
+      <th id="T_fda38_level0_col2" class="col_heading level0 col2" >Avg</th>
+      <th id="T_fda38_level0_col3" class="col_heading level0 col3" >Med</th>
+      <th id="T_fda38_level0_col4" class="col_heading level0 col4" >Min</th>
+      <th id="T_fda38_level0_col5" class="col_heading level0 col5" >Max</th>
+      <th id="T_fda38_level0_col6" class="col_heading level0 col6" >%ctile</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td><a href="qqq_pe.html">QQQ</a></td>
-      <td>TTM</td>
-      <td>Avg</td>
-      <td>33.3</td>
-    </tr>
-    <tr>
-      <td><a href="qqq_pe.html">QQQ</a></td>
-      <td>TTM</td>
-      <td>Med</td>
-      <td>33.4</td>
-    </tr>
-    <tr>
-      <td><a href="qqq_pe.html">QQQ</a></td>
-      <td>TTM</td>
-      <td>Min</td>
-      <td>32.3</td>
-    </tr>
-    <tr>
-      <td><a href="qqq_pe.html">QQQ</a></td>
-      <td>TTM</td>
-      <td>Max</td>
-      <td>34.3</td>
+      <td id="T_fda38_row0_col0" class="data row0 col0" >P/E Ratio (TTM)</td>
+      <td id="T_fda38_row0_col1" class="data row0 col1" >33.68</td>
+      <td id="T_fda38_row0_col2" class="data row0 col2" >33.31</td>
+      <td id="T_fda38_row0_col3" class="data row0 col3" >33.40</td>
+      <td id="T_fda38_row0_col4" class="data row0 col4" >32.33</td>
+      <td id="T_fda38_row0_col5" class="data row0 col5" >34.27</td>
+      <td id="T_fda38_row0_col6" class="data row0 col6" >71</td>
     </tr>
   </tbody>
 </table>

--- a/index_growth_charts.py
+++ b/index_growth_charts.py
@@ -105,13 +105,10 @@ def _build_html(df):
     return SUMMARY_CSS + sty.to_html()
 
 def _save_tables(tk, ig_df, pe_df):
+    tk_lower = tk.lower()
     files = {
-        f"{tk}_implied_growth_summary.html": _build_html(ig_df),
-        f"{tk.lower()}_growth_summary.html": _build_html(ig_df),
-        f"{tk}_growth_tbl.html":             _build_html(ig_df),   # legacy
-
-        f"{tk}_pe_ratio_summary.html":       _build_html(pe_df),
-        f"{tk.lower()}_pe_summary.html":     _build_html(pe_df)
+        f"{tk_lower}_growth_summary.html": _build_html(ig_df),
+        f"{tk_lower}_pe_summary.html":     _build_html(pe_df),
     }
     for name, html in files.items():
         with open(os.path.join(OUT_DIR, name), "w", encoding="utf-8") as f:
@@ -124,9 +121,9 @@ def render_index_growth_charts(tk="SPY"):
         pe_s = _series_pe(conn, tk)
 
     _chart(ig_s, f"{tk} Implied Growth (TTM)",
-           "Implied Growth Rate", f"{tk}_implied_growth.png")
+           "Implied Growth Rate", f"{tk.lower()}_growth_chart.png")
     _chart(pe_s, f"{tk} P/E Ratio", "P/E",
-           f"{tk}_pe_ratio.png")
+           f"{tk.lower()}_pe_chart.png")
 
     _save_tables(
         tk,

--- a/main_remote.py
+++ b/main_remote.py
@@ -29,7 +29,6 @@ from eps_dividend_generator    import eps_dividend_generator
 from index_growth_charts       import render_index_growth_charts
 from generate_earnings_tables  import generate_earnings_tables
 from backfill_index_growth     import backfill_index_growth
-from generate_index_growth_pages import generate_index_growth_pages
 
 # We no longer call the second table generator; chart writer owns the table.
 from generate_segment_charts   import generate_segment_charts_for_ticker
@@ -202,9 +201,11 @@ def mini_main():
         log_average_valuations(avg_vals, TICKERS_FILE_PATH)
         spy_qqq_html = index_growth(treasury)
         generate_earnings_tables()
-        render_index_growth_charts()
+        # Generate index growth charts for both SPY and QQQ so that
+        # their growth pages share the same styled summaries.
+        for idx in ("SPY", "QQQ"):
+            render_index_growth_charts(idx)
         backfill_index_growth()
-        generate_index_growth_pages()
 
         html_generator2(
             tickers,

--- a/qqq_growth.html
+++ b/qqq_growth.html
@@ -8,81 +8,85 @@
 
   <h2>Implied Growth (TTM)</h2>
   <img src="../charts/qqq_growth_chart.png" alt="QQQ growth chart" style="max-width:100%;">
-  <table border="1" class="dataframe">
+  
+<style>
+.summary-table{width:100%;border-collapse:collapse;
+  font-family:Verdana,Arial,sans-serif;font-size:12px;
+  border:3px solid #003366;}
+.summary-table th{background:#f2f2f2;padding:4px 6px;
+  border:1px solid #B0B0B0;text-align:center;}
+.summary-table td{padding:4px 6px;border:1px solid #B0B0B0;text-align:center;}
+</style>
+<style type="text/css">
+</style>
+<table id="T_26845" class="summary-table">
   <thead>
-    <tr style="text-align: right;">
-      <th>Ticker</th>
-      <th>Type</th>
-      <th>Stat</th>
-      <th>Value</th>
+    <tr>
+      <th id="T_26845_level0_col0" class="col_heading level0 col0" >Metric</th>
+      <th id="T_26845_level0_col1" class="col_heading level0 col1" >Latest</th>
+      <th id="T_26845_level0_col2" class="col_heading level0 col2" >Avg</th>
+      <th id="T_26845_level0_col3" class="col_heading level0 col3" >Med</th>
+      <th id="T_26845_level0_col4" class="col_heading level0 col4" >Min</th>
+      <th id="T_26845_level0_col5" class="col_heading level0 col5" >Max</th>
+      <th id="T_26845_level0_col6" class="col_heading level0 col6" >%ctile</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td><a href="qqq_growth.html">QQQ</a></td>
-      <td>TTM</td>
-      <td>Avg</td>
-      <td>43.71%</td>
-    </tr>
-    <tr>
-      <td><a href="qqq_growth.html">QQQ</a></td>
-      <td>TTM</td>
-      <td>Med</td>
-      <td>43.21%</td>
-    </tr>
-    <tr>
-      <td><a href="qqq_growth.html">QQQ</a></td>
-      <td>TTM</td>
-      <td>Min</td>
-      <td>37.91%</td>
-    </tr>
-    <tr>
-      <td><a href="qqq_growth.html">QQQ</a></td>
-      <td>TTM</td>
-      <td>Max</td>
-      <td>50.51%</td>
+      <td id="T_26845_row0_col0" class="data row0 col0" >Implied Growth (TTM)</td>
+      <td id="T_26845_row0_col1" class="data row0 col1" >42.12 %</td>
+      <td id="T_26845_row0_col2" class="data row0 col2" >43.80 %</td>
+      <td id="T_26845_row0_col3" class="data row0 col3" >43.21 %</td>
+      <td id="T_26845_row0_col4" class="data row0 col4" >40.17 %</td>
+      <td id="T_26845_row0_col5" class="data row0 col5" >50.51 %</td>
+      <td id="T_26845_row0_col6" class="data row0 col6" >35</td>
     </tr>
   </tbody>
 </table>
 
+
   <h2>P/E Ratio (TTM)</h2>
   <img src="../charts/qqq_pe_chart.png" alt="QQQ P/E chart" style="max-width:100%;">
-  <table border="1" class="dataframe">
+  
+<style>
+.summary-table{width:100%;border-collapse:collapse;
+  font-family:Verdana,Arial,sans-serif;font-size:12px;
+  border:3px solid #003366;}
+.summary-table th{background:#f2f2f2;padding:4px 6px;
+  border:1px solid #B0B0B0;text-align:center;}
+.summary-table td{padding:4px 6px;border:1px solid #B0B0B0;text-align:center;}
+</style>
+<style type="text/css">
+#T_fda38_row0_col6 {
+  color: #CC0000;
+  font-weight: bold;
+}
+</style>
+<table id="T_fda38" class="summary-table">
   <thead>
-    <tr style="text-align: right;">
-      <th>Ticker</th>
-      <th>Type</th>
-      <th>Stat</th>
-      <th>Value</th>
+    <tr>
+      <th id="T_fda38_level0_col0" class="col_heading level0 col0" >Metric</th>
+      <th id="T_fda38_level0_col1" class="col_heading level0 col1" >Latest</th>
+      <th id="T_fda38_level0_col2" class="col_heading level0 col2" >Avg</th>
+      <th id="T_fda38_level0_col3" class="col_heading level0 col3" >Med</th>
+      <th id="T_fda38_level0_col4" class="col_heading level0 col4" >Min</th>
+      <th id="T_fda38_level0_col5" class="col_heading level0 col5" >Max</th>
+      <th id="T_fda38_level0_col6" class="col_heading level0 col6" >%ctile</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td><a href="qqq_pe.html">QQQ</a></td>
-      <td>TTM</td>
-      <td>Avg</td>
-      <td>33.3</td>
-    </tr>
-    <tr>
-      <td><a href="qqq_pe.html">QQQ</a></td>
-      <td>TTM</td>
-      <td>Med</td>
-      <td>33.4</td>
-    </tr>
-    <tr>
-      <td><a href="qqq_pe.html">QQQ</a></td>
-      <td>TTM</td>
-      <td>Min</td>
-      <td>32.3</td>
-    </tr>
-    <tr>
-      <td><a href="qqq_pe.html">QQQ</a></td>
-      <td>TTM</td>
-      <td>Max</td>
-      <td>34.3</td>
+      <td id="T_fda38_row0_col0" class="data row0 col0" >P/E Ratio (TTM)</td>
+      <td id="T_fda38_row0_col1" class="data row0 col1" >33.68</td>
+      <td id="T_fda38_row0_col2" class="data row0 col2" >33.31</td>
+      <td id="T_fda38_row0_col3" class="data row0 col3" >33.40</td>
+      <td id="T_fda38_row0_col4" class="data row0 col4" >32.33</td>
+      <td id="T_fda38_row0_col5" class="data row0 col5" >34.27</td>
+      <td id="T_fda38_row0_col6" class="data row0 col6" >71</td>
     </tr>
   </tbody>
 </table>
+
 
   <p><a href="../index.html">← Back to Dashboard</a></p>
 </div></body></html>


### PR DESCRIPTION
## Summary
- Remove unused QQQ summary artifacts so only the formatted QQQ growth page remains
- Streamline index growth chart generation to emit lower-case assets for SPY/QQQ and drop extra page generation

## Testing
- `pytest` *(fails: SystemExit: ERROR: export Email='your.sec.address@example.com' first)*

------
https://chatgpt.com/codex/tasks/task_e_68baf294ed2c83319dc2e34a1a8575df