### PR TITLE
Honor caller's output directory for raw segment data

### DIFF
--- a/generate_segment_charts.py
+++ b/generate_segment_charts.py
@@ -144,7 +144,7 @@ def _last3_plus_ttm(years: List[str]) -> List[str]:
 def generate_segment_charts_for_ticker(ticker: str, out_dir: Path) -> None:
     """Generate charts and a compact pivot HTML table for a single ticker."""
     try:
-        df = get_segment_data(ticker, dump_raw=True)
+        df = get_segment_data(ticker, dump_raw=True, raw_dir=out_dir)
     except Exception as fetch_err:
         print(f"[{VERSION}] Error fetching segment data for {ticker}: {fetch_err}")
         ensure_dir(out_dir)

--- a/generate_segment_charts.py
+++ b/generate_segment_charts.py
@@ -143,6 +143,7 @@ def _last3_plus_ttm(years: List[str]) -> List[str]:
 
 def generate_segment_charts_for_ticker(ticker: str, out_dir: Path) -> None:
     """Generate charts and a compact pivot HTML table for a single ticker."""
+    ticker = ticker.upper()
     try:
         df = get_segment_data(ticker, dump_raw=True, raw_dir=out_dir)
     except Exception as fetch_err:
@@ -352,10 +353,10 @@ def main():
     with review_path.open("w", encoding="utf-8") as review:
         for idx, ticker in enumerate(tickers, start=1):
             print(f"[{idx}/{len(tickers)}] Processing {ticker}…")
-            ticker_dir = output_dir / ticker
+            ticker_dir = output_dir / ticker.upper()
             generate_segment_charts_for_ticker(ticker, ticker_dir)
 
-            raw_file = ticker_dir / f"{ticker}_segment_raw.txt"
+            raw_file = ticker_dir / f"{ticker.upper()}_segment_raw.txt"
             if raw_file.exists():
                 review.write(f"---- {ticker.upper()} ----\n\n")
                 review.write(raw_file.read_text(encoding="utf-8"))

--- a/generate_segment_tables.py
+++ b/generate_segment_tables.py
@@ -112,7 +112,7 @@ def main():
     for i, t in enumerate(TICKERS, start=1):
         try:
             print(f"[{i}/{len(TICKERS)}] fetching {t}…")
-            df = get_segment_data(t, dump_raw=True)
+            df = get_segment_data(t, dump_raw=True, raw_dir=OUTPUT_DIR / t)
             html = render_table_html(t, df)
             out_file = OUTPUT_DIR / f"{t}_segments.html"
             save_html(out_file, html)

--- a/generate_segment_tables.py
+++ b/generate_segment_tables.py
@@ -110,6 +110,7 @@ def save_html(path: Path, html: str):
 def main():
     all_snippets = []
     for i, t in enumerate(TICKERS, start=1):
+        t = t.upper()
         try:
             print(f"[{i}/{len(TICKERS)}] fetching {t}…")
             df = get_segment_data(t, dump_raw=True, raw_dir=OUTPUT_DIR / t)

--- a/sec_segment_data_arelle.py
+++ b/sec_segment_data_arelle.py
@@ -428,7 +428,7 @@ def compute_segment_ttm(fy_df: pd.DataFrame, q_df: pd.DataFrame) -> pd.DataFrame
 
 
 def get_segment_data(
-    ticker: str, *, dump_raw: bool = False, raw_dir: Path | None = None
+    ticker: str, *, dump_raw: bool = False, raw_dir: Path | str | None = None
 ) -> pd.DataFrame:
     """Fetch segment-level revenue & operating income for ``ticker``.
 
@@ -441,8 +441,9 @@ def get_segment_data(
         ``{raw_dir}/{ticker}_segment_raw.txt``. Defaults to ``False``.
     raw_dir:
         Directory in which the raw text file should be written when
-        ``dump_raw`` is ``True``. If ``None`` (the default), the file is written
-        to ``charts/{ticker}`` relative to the current working directory.
+        ``dump_raw`` is ``True``. May be a ``Path`` or string. If ``None`` (the
+        default), the file is written to ``charts/{ticker}`` relative to the
+        current working directory.
 
     Returns
     -------
@@ -495,7 +496,11 @@ def get_segment_data(
             if raw_facts
             else pd.DataFrame(columns=["Concept", "PeriodEnd", "Dims", "Value"])
         )
-        out_dir = (raw_dir or Path("charts") / ticker.upper()).resolve()
+        out_dir = (
+            Path(raw_dir).resolve()
+            if raw_dir
+            else (Path("charts") / ticker.upper()).resolve()
+        )
         out_dir.mkdir(parents=True, exist_ok=True)
         raw_path = out_dir / f"{ticker.upper()}_segment_raw.txt"
         try:


### PR DESCRIPTION
## Summary
- Add optional `raw_dir` parameter to `get_segment_data` so callers can control where raw segment facts are written
- Pass ticker-specific output directories from chart and table generators ensuring raw data lands in `charts/<TICKER>`

## Testing
- `python -m py_compile sec_segment_data_arelle.py generate_segment_charts.py generate_segment_tables.py`
- `python - <<'PY' ...` *(ProxyError: HTTPSConnectionPool(host='data.sec.gov', port=443) ...)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2de3a4588331b30772ad179c5ad2