### PR TITLE
Expand earnings history ingestion

### DIFF
--- a/generate_earnings_tables.py
+++ b/generate_earnings_tables.py
@@ -72,8 +72,8 @@ def generate_earnings_tables():
                 idx = idx.tz_localize(None, errors="ignore").normalize()
             df.index = idx
 
-            recent = df[(df.index >= seven_days_ago) & (df.index <= today)]
-            for edate, row in recent.iterrows():
+            historical = df[df.index <= today]
+            for edate, row in historical.iterrows():
                 surprise = pd.to_numeric(row.get('Surprise(%)'), errors='coerce')
                 eps_est  = row.get('EPS Estimate')
                 rpt_eps  = row.get('Reported EPS')
@@ -108,6 +108,11 @@ def generate_earnings_tables():
 
         except Exception as e:
             logging.error(f"Error processing {ticker}: {e}")
+
+    cursor.execute(
+        "DELETE FROM earnings_upcoming WHERE earnings_date <= ?",
+        (today.date().isoformat(),)
+    )
 
     conn.commit()
     conn.close()


### PR DESCRIPTION
## Summary
- upsert all historical earnings dates returned by yfinance into the `earnings_past` table instead of limiting to the trailing week
- remove outdated rows from `earnings_upcoming` so the dashboard query relies on fresh entries

## Testing
- python render_earnings_to_dashboard.py *(fails to download yfinance data in this environment; curl 403 errors)*
- sqlite3 'Stock Data.db' 'SELECT MAX(earnings_date) FROM earnings_past;'


------
https://chatgpt.com/codex/tasks/task_e_68cae76b679c83319fa3b5a1308ce444