### PR TITLE
Fix implied growth charts for decimal data

### DIFF
--- a/Test/test_index_growth_charts.py
+++ b/Test/test_index_growth_charts.py
@@ -1,0 +1,49 @@
+import pathlib
+import sys
+from unittest.mock import patch
+
+import pandas as pd
+import pandas.testing as pdt
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import index_growth_charts as igc
+
+
+def test_render_index_growth_charts_scales_decimal_series():
+    dates = pd.date_range("2024-03-31", periods=3, freq="QE-DEC")
+    decimal_growth = pd.Series([0.10, 0.25, 0.40], index=dates)
+    pe_series = pd.Series([15.0, 16.5, 14.2], index=dates)
+
+    captured = []
+
+    with (
+        patch.object(igc, "sqlite3") as mock_sqlite,
+        patch.object(igc, "_series_growth", return_value=decimal_growth) as mock_growth,
+        patch.object(igc, "_series_pe", return_value=pe_series) as mock_pe,
+        patch.object(igc, "_chart") as mock_chart,
+        patch.object(igc, "_save_tables") as mock_save,
+    ):
+        fake_conn = object()
+        mock_sqlite.connect.return_value.__enter__.return_value = fake_conn
+
+        def capture(series, title, ylabel, fname):
+            captured.append((series, title, ylabel, fname))
+            return "ignored.png"
+
+        mock_chart.side_effect = capture
+
+        igc.render_index_growth_charts("TEST")
+
+    # Ensure the growth chart received values scaled to the 0-100 range.
+    assert captured, "Expected the chart helper to be invoked at least once"
+    growth_series, _, growth_ylabel, _ = captured[0]
+    pdt.assert_series_equal(growth_series, decimal_growth * 100, check_names=False)
+    assert growth_ylabel == "Implied Growth Rate (%)"
+
+    # Confirm the helper series functions were invoked with the mocked connection.
+    mock_growth.assert_called_once_with(fake_conn, "TEST")
+    mock_pe.assert_called_once_with(fake_conn, "TEST")
+    mock_save.assert_called_once()

--- a/index_growth_charts.py
+++ b/index_growth_charts.py
@@ -120,8 +120,23 @@ def render_index_growth_charts(tk="SPY"):
         ig_s = _series_growth(conn, tk)
         pe_s = _series_pe(conn, tk)
 
-    _chart(ig_s, f"{tk} Implied Growth (TTM)",
-           "Implied Growth Rate", f"{tk.lower()}_growth_chart.png")
+    ig_plot = ig_s
+    ig_ylabel = "Implied Growth Rate"
+    if not ig_s.empty:
+        med = ig_s.median(skipna=True)
+        max_abs = ig_s.abs().max()
+        if (
+            pd.notna(med) and np.isfinite(med)
+            and abs(med) < 1
+            and pd.notna(max_abs) and np.isfinite(max_abs)
+            and max_abs <= 2
+        ):
+            # Stored as decimals (e.g., 0.18 for 18%) → scale a copy for plotting.
+            ig_plot = ig_s * 100
+            ig_ylabel = "Implied Growth Rate (%)"
+
+    _chart(ig_plot, f"{tk} Implied Growth (TTM)",
+           ig_ylabel, f"{tk.lower()}_growth_chart.png")
     _chart(pe_s, f"{tk} P/E Ratio", "P/E",
            f"{tk.lower()}_pe_chart.png")
 


### PR DESCRIPTION
## Summary
- scale implied growth rate series for charting when stored as decimals and update the plot label
- add a regression test that feeds a decimal growth series through the renderer and verifies the plotted values are on a 0–100 scale

## Testing
- pytest Test/test_index_growth_charts.py

------
https://chatgpt.com/codex/tasks/task_e_68ccb8f7b404833187c8602986511406