### PR TITLE
Display revenue as separate bars

### DIFF
--- a/expense_reports.py
+++ b/expense_reports.py
@@ -223,23 +223,34 @@ def _cats(df: pd.DataFrame, combo_present: bool):
 
 def _chart_abs(df: pd.DataFrame, tkr: str):
     f      = df.sort_values("year_int")
-    x      = f["year_label"].tolist()
+    x_lab  = f["year_label"].tolist()
+    idx    = np.arange(len(f))
+    width  = 0.38
     cats   = _cats(f, f["sga_combined"].notna().any())
     fig, ax = plt.subplots(figsize=(11, 6))
-    bottom = np.zeros(len(f), dtype=float)
 
+    revenue_vals = f["total_revenue"].fillna(0).astype(float).values
+    ax.bar(idx - width / 2, revenue_vals, width=width, color="#4a4a4a", label="Revenue")
+
+    bottom = np.zeros(len(f), dtype=float)
     for lbl, col, colour in cats:
         vals = f[col].fillna(0).astype(float).values
-        ax.bar(x, vals, bottom=bottom, color=colour, width=0.6, label=lbl)
+        ax.bar(idx + width / 2, vals, bottom=bottom, color=colour, width=width, label=lbl)
         bottom += vals
 
-    ax.plot(x, f["total_revenue"].astype(float), "k-o", lw=2, label="Revenue")
-    ax.set_ylim(0, max(bottom.max(), f["total_revenue"].max()) * 1.1)
+    ymax = max(bottom.max(), revenue_vals.max()) * 1.1 if len(f) else 1
+    ax.set_ylim(0, ymax)
+    ax.set_xticks(idx)
+    ax.set_xticklabels(x_lab)
     ax.set_title(f"Revenue vs Operating Expenses — {tkr}")
     ax.yaxis.set_major_formatter(FuncFormatter(lambda val, _: _fmt_short(val)))
     ax.legend(frameon=False, ncol=2)
     plt.tight_layout()
-    plt.savefig(os.path.join(OUTPUT_DIR, f"{tkr}_expenses_vs_revenue.png"))
+    for name in (
+        f"{tkr}_expenses_vs_revenue.png",
+        f"{tkr}_rev_expense_chart.png",
+    ):
+        plt.savefig(os.path.join(OUTPUT_DIR, name))
     plt.close()
 
 
@@ -285,10 +296,18 @@ def _chart_pct(df: pd.DataFrame, tkr: str):
     fig.subplots_adjust(right=0.78, top=0.88)
     plt.tight_layout()
 
-    out = os.path.join(OUTPUT_DIR, f"{tkr}_expenses_pct_of_rev.png")
-    fig.savefig(out, dpi=120, bbox_inches="tight")
+    for name in (
+        f"{tkr}_expenses_pct_of_rev.png",
+        f"{tkr}_expense_percent_chart.png",
+    ):
+        fig.savefig(
+            os.path.join(OUTPUT_DIR, name), dpi=120, bbox_inches="tight"
+        )
     plt.close()
-    print(f"[{tkr}] expense-% chart saved → {out}")
+    print(
+        f"[{tkr}] expense-% chart saved → "
+        f"{os.path.join(OUTPUT_DIR, f'{tkr}_expenses_pct_of_rev.png')}"
+    )
 
 
 # ─────────────────────────── tables ────────────────────────────


### PR DESCRIPTION
## Summary
- plot revenue as its own bar next to the stacked operating expenses for each period
- keep the legacy and new filenames in sync while using grouped bar positions

## Testing
- python -m compileall expense_reports.py

------
https://chatgpt.com/codex/tasks/task_e_68d36d5ec70883319ad598f88e35dba1