### PR TITLE
Backfill SPY/QQQ PE history from Yahoo earnings data

### DIFF
--- a/Test/test_backfill_index_pe_history.py
+++ b/Test/test_backfill_index_pe_history.py
@@ -1,0 +1,110 @@
+import pathlib
+import sqlite3
+import sys
+
+import pandas as pd
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backfill_index_pe_history import (
+    _compute_eps_windows,
+    _merge_prices_with_eps,
+    _ensure_tables,
+    _has_history,
+    _upsert_history,
+)
+
+
+def test_compute_eps_windows_produces_ttm_and_forward_eps():
+    quarters = pd.date_range("2020-03-31", periods=8, freq="QE-DEC")
+    earnings = pd.DataFrame(
+        {
+            "epsActual": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+            "epsEstimate": [
+                1.1,
+                2.1,
+                3.1,
+                4.1,
+                5.1,
+                6.1,
+                7.1,
+                8.1,
+            ],
+        },
+        index=quarters,
+    )
+
+    result = _compute_eps_windows(earnings)
+    result = result.set_index("date")
+
+    # Trailing EPS should sum the last four actual values.
+    assert result.loc[pd.Timestamp("2020-12-31"), "ttm_eps"] == pytest.approx(10.0)
+    assert result.loc[pd.Timestamp("2021-03-31"), "ttm_eps"] == pytest.approx(14.0)
+
+    # Forward EPS should sum the next four estimates when available.
+    assert result.loc[pd.Timestamp("2020-03-31"), "forward_eps"] == pytest.approx(10.4)
+    assert result.loc[pd.Timestamp("2020-06-30"), "forward_eps"] == pytest.approx(14.4)
+
+
+def test_merge_prices_with_eps_aligns_latest_quarter():
+    prices = pd.DataFrame(
+        {
+            "date": pd.date_range("2020-01-01", periods=5, freq="D"),
+            "close": [10.0, 20.0, 30.0, 40.0, 50.0],
+        }
+    )
+    eps = pd.DataFrame(
+        {
+            "date": [pd.Timestamp("2020-01-02"), pd.Timestamp("2020-01-04")],
+            "ttm_eps": [1.0, 2.0],
+            "forward_eps": [1.5, 2.5],
+        }
+    )
+
+    merged = _merge_prices_with_eps(prices, eps)
+
+    # As of 2020-01-03 we should still be using the 2020-01-02 EPS snapshot.
+    row = merged.loc[merged["date"] == pd.Timestamp("2020-01-03")].iloc[0]
+    assert row["pe_ttm"] == 30.0
+    assert row["pe_forward"] == 20.0
+
+    # Once the 2020-01-04 EPS arrives, subsequent days use the updated ratios.
+    row = merged.loc[merged["date"] == pd.Timestamp("2020-01-05")].iloc[0]
+    assert row["pe_ttm"] == 25.0
+    assert row["pe_forward"] == 20.0
+
+
+def test_upsert_history_creates_rows_and_has_history_flag():
+    conn = sqlite3.connect(":memory:")
+    try:
+        _ensure_tables(conn)
+
+        history = pd.DataFrame(
+            {
+                "date": [pd.Timestamp("2020-01-01"), pd.Timestamp("2020-01-02")],
+                "pe_ttm": [15.0, 16.0],
+                "pe_forward": [14.0, pd.NA],
+            }
+        )
+
+        inserted = _upsert_history(conn, "TEST", history)
+        assert inserted == 3  # two TTM rows + one forward
+
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT Date, PE_Type, PE_Ratio FROM Index_PE_History ORDER BY Date, PE_Type"
+        )
+        rows = cur.fetchall()
+        assert rows == [
+            ("2020-01-01", "Forward", 14.0),
+            ("2020-01-01", "TTM", 15.0),
+            ("2020-01-02", "TTM", 16.0),
+        ]
+
+        assert not _has_history(conn, "TEST", pd.Timestamp("2019-12-31"))
+        assert _has_history(conn, "TEST", pd.Timestamp("2020-01-01"))
+    finally:
+        conn.close()

--- a/backfill_index_pe_history.py
+++ b/backfill_index_pe_history.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Backfill SPY/QQQ P/E history using Yahoo Finance earnings + price data.
+
+This module downloads the last N years of daily closing prices alongside
+quarterly EPS information in order to reconstruct historical trailing and
+forward P/E ratios.  Results are persisted to the ``Index_PE_History`` table
+and can subsequently be converted into implied growth via the existing
+``backfill_index_growth`` helper.
+
+Only lightweight helper functions are unit-tested; the network calls rely on
+``yfinance`` and are expected to run in the production environment.
+"""
+
+from __future__ import annotations
+
+import math
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Iterable, Optional
+
+import pandas as pd
+import yfinance as yf
+
+
+DB_PATH = "Stock Data.db"
+DEFAULT_TICKERS: tuple[str, ...] = ("SPY", "QQQ")
+
+
+@dataclass
+class PEHistory:
+    """Container for computed trailing/forward P/E rows."""
+
+    date: pd.Timestamp
+    pe_ttm: Optional[float]
+    pe_forward: Optional[float]
+
+
+def _ensure_tables(conn: sqlite3.Connection) -> None:
+    """Guarantee the P/E history table exists."""
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS Index_PE_History (
+            Date    TEXT,
+            Ticker  TEXT,
+            PE_Type TEXT,
+            PE_Ratio REAL,
+            PRIMARY KEY (Date, Ticker, PE_Type)
+        );
+        """
+    )
+
+
+def _has_history(conn: sqlite3.Connection, ticker: str, start_date: datetime) -> bool:
+    """Return True if the DB already has history reaching *start_date*."""
+
+    row = conn.execute(
+        """
+        SELECT MIN(Date)
+          FROM Index_PE_History
+         WHERE Ticker=? AND PE_Type='TTM'
+        """,
+        (ticker,),
+    ).fetchone()
+    if not row or not row[0]:
+        return False
+    try:
+        earliest = datetime.strptime(row[0], "%Y-%m-%d")
+    except ValueError:
+        return False
+    return earliest <= start_date
+
+
+def _compute_eps_windows(raw: pd.DataFrame) -> pd.DataFrame:
+    """Compute trailing and forward EPS aggregates from earnings history."""
+
+    if raw is None or raw.empty:
+        return pd.DataFrame(columns=["date", "ttm_eps", "forward_eps"])
+
+    df = raw.copy()
+    if df.index.name != "quarter":
+        df.index.name = "quarter"
+    df = df.sort_index()
+    for col in ("epsActual", "epsEstimate"):
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+        else:
+            df[col] = pd.Series(dtype=float)
+
+    df["ttm_eps"] = df["epsActual"].rolling(window=4, min_periods=4).sum()
+    df["forward_eps"] = df["epsEstimate"][::-1].rolling(window=4, min_periods=4).sum()[::-1]
+
+    out = (
+        df[["ttm_eps", "forward_eps"]]
+        .dropna(how="all")
+        .reset_index()
+        .rename(columns={"quarter": "date"})
+    )
+    out["date"] = pd.to_datetime(out["date"], errors="coerce").dt.normalize()
+    return out.dropna(subset=["date"]).sort_values("date")
+
+
+def _merge_prices_with_eps(prices: pd.DataFrame, eps: pd.DataFrame) -> pd.DataFrame:
+    """Align daily closes with the most recent EPS aggregates."""
+
+    if prices is None or prices.empty or eps is None or eps.empty:
+        return pd.DataFrame(columns=["date", "pe_ttm", "pe_forward"])
+
+    price_df = prices.copy()
+    price_df["date"] = pd.to_datetime(price_df["date"], errors="coerce").dt.normalize()
+    price_df = price_df.dropna(subset=["date", "close"]).sort_values("date")
+
+    eps_df = eps.copy()
+    eps_df["date"] = pd.to_datetime(eps_df["date"], errors="coerce").dt.normalize()
+    eps_df = eps_df.dropna(subset=["date"]).sort_values("date")
+
+    merged = pd.merge_asof(price_df, eps_df, on="date", direction="backward")
+    if merged.empty:
+        return pd.DataFrame(columns=["date", "pe_ttm", "pe_forward"])
+
+    merged["pe_ttm"] = merged["close"] / merged["ttm_eps"]
+    merged.loc[(merged["ttm_eps"] <= 0) | merged["ttm_eps"].isna(), "pe_ttm"] = pd.NA
+
+    if "forward_eps" in merged.columns:
+        merged["pe_forward"] = merged["close"] / merged["forward_eps"]
+        merged.loc[
+            (merged["forward_eps"] <= 0) | merged["forward_eps"].isna(), "pe_forward"
+        ] = pd.NA
+    else:
+        merged["pe_forward"] = pd.NA
+
+    keep_cols = ["date", "pe_ttm", "pe_forward"]
+    return merged[keep_cols].dropna(subset=["pe_ttm"], how="all").sort_values("date")
+
+
+def _download_prices(ticker: str, start: datetime, end: datetime) -> pd.DataFrame:
+    """Fetch daily close prices via yfinance."""
+
+    data = yf.download(
+        ticker,
+        start=start.strftime("%Y-%m-%d"),
+        end=end.strftime("%Y-%m-%d"),
+        progress=False,
+        interval="1d",
+        auto_adjust=False,
+    )
+    if data.empty:
+        return pd.DataFrame(columns=["date", "close"])
+    data = data.reset_index()
+    return data.rename(columns={"Date": "date", "Close": "close"})[["date", "close"]]
+
+
+def _compute_history(ticker: str, start: datetime, end: datetime) -> pd.DataFrame:
+    """Return a dataframe of daily P/E values between *start* and *end*."""
+
+    ticker_obj = yf.Ticker(ticker)
+    earnings = ticker_obj.get_earnings_history()
+    eps_df = _compute_eps_windows(earnings)
+    prices = _download_prices(ticker, start, end)
+    history = _merge_prices_with_eps(prices, eps_df)
+    if history.empty:
+        return history
+    history = history[(history["date"] >= pd.Timestamp(start)) & (history["date"] <= pd.Timestamp(end))]
+    return history
+
+
+def _iter_pe_rows(df: pd.DataFrame) -> Iterable[PEHistory]:
+    for _, row in df.iterrows():
+        date = pd.to_datetime(row["date"], errors="coerce")
+        if pd.isna(date):
+            continue
+        pe_ttm = row.get("pe_ttm")
+        pe_forward = row.get("pe_forward") if "pe_forward" in row else None
+
+        def _clean(value: Optional[float]) -> Optional[float]:
+            if pd.isna(value):
+                return None
+            if isinstance(value, (float, int)) and math.isfinite(float(value)):
+                return float(value)
+            return None
+
+        yield PEHistory(date=date, pe_ttm=_clean(pe_ttm), pe_forward=_clean(pe_forward))
+
+
+def _upsert_history(conn: sqlite3.Connection, ticker: str, history: pd.DataFrame) -> int:
+    """Insert P/E values into the database, returning number of rows written."""
+
+    if history is None or history.empty:
+        return 0
+
+    rows = []
+    for item in _iter_pe_rows(history):
+        date_str = item.date.strftime("%Y-%m-%d")
+        if item.pe_ttm is not None:
+            rows.append((date_str, ticker, "TTM", item.pe_ttm))
+        if item.pe_forward is not None:
+            rows.append((date_str, ticker, "Forward", item.pe_forward))
+
+    if not rows:
+        return 0
+
+    conn.executemany(
+        """
+        INSERT OR REPLACE INTO Index_PE_History (Date, Ticker, PE_Type, PE_Ratio)
+        VALUES (?, ?, ?, ?)
+        """,
+        rows,
+    )
+    return len(rows)
+
+
+def backfill_index_pe_history(
+    years: int = 10,
+    tickers: Iterable[str] = DEFAULT_TICKERS,
+    db_path: str = DB_PATH,
+    force: bool = False,
+) -> None:
+    """Populate ``Index_PE_History`` with up to *years* of history for each ticker."""
+
+    end = datetime.utcnow().date()
+    start = end - timedelta(days=int(years * 365.25))
+    end_dt = datetime.combine(end + timedelta(days=1), datetime.min.time())
+    start_dt = datetime.combine(start, datetime.min.time())
+
+    with sqlite3.connect(db_path) as conn:
+        _ensure_tables(conn)
+
+        for ticker in tickers:
+            if not force and _has_history(conn, ticker, start_dt):
+                print(f"[backfill_index_pe_history] {ticker}: history already covers {start_dt.date()}")
+                continue
+
+            try:
+                history = _compute_history(ticker, start_dt, end_dt)
+            except Exception as exc:  # pragma: no cover - network errors
+                print(f"[backfill_index_pe_history] Failed to compute history for {ticker}: {exc}")
+                continue
+
+            inserted = _upsert_history(conn, ticker, history)
+            print(f"[backfill_index_pe_history] {ticker}: wrote {inserted} rows")
+
+        conn.commit()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    backfill_index_pe_history()

--- a/main_remote.py
+++ b/main_remote.py
@@ -29,6 +29,7 @@ from eps_dividend_generator    import eps_dividend_generator
 from index_growth_charts       import render_index_growth_charts
 from generate_earnings_tables  import generate_earnings_tables
 from backfill_index_growth     import backfill_index_growth
+from backfill_index_pe_history import backfill_index_pe_history
 
 # We no longer call the second table generator; chart writer owns the table.
 from generate_segment_charts   import generate_segment_charts_for_ticker
@@ -151,6 +152,8 @@ def mini_main():
 
     financial_data, dashboard_data = {}, []
     treasury = fetch_10_year_treasury_yield()
+    backfill_index_pe_history(years=10)
+    backfill_index_growth()
 
     tickers = manage_tickers(TICKERS_FILE_PATH, is_remote=True)
     conn = establish_database_connection(DB_PATH)
@@ -205,7 +208,6 @@ def mini_main():
         # their growth pages share the same styled summaries.
         for idx in ("SPY", "QQQ"):
             render_index_growth_charts(idx)
-        backfill_index_growth()
 
         html_generator2(
             tickers,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_files = Test/test_*.py


### PR DESCRIPTION
## Summary
- add a Yahoo Finance–powered backfill script that reconstructs trailing and forward P/E history for SPY/QQQ and stores it in `Index_PE_History`
- invoke the backfill ahead of the existing index-growth generation pipeline so charts pick up the extended history
- add focused unit tests and limit pytest discovery to the dedicated `Test/` suite

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d37268e08883319bd5338f85afea24